### PR TITLE
Fix status cursor animation using too much GPU

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^7.1.2",
     "jsdocgen": "^0.2.4",
     "socket.io-client": "^2.0.4",
-    "typeit": "^4.4.1",
+    "typeit": "^8.0.2",
     "v-hotkey": "^0.2.0",
     "vue": "^2.3.3",
     "vue-docgen-api": "^2.3.13",

--- a/src/components/kytos/misc/StatusBar.vue
+++ b/src/components/kytos/misc/StatusBar.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+import TypeIt from "typeit";
 /**
  * A GUI widget the shows notifications and System Information.
  *
@@ -32,11 +33,11 @@ export default {
     display_messages(){
       var message= this.messages.shift()
       if (message !== undefined){
-        this.get_terminal().tiType(message).tiPause(1500).tiDelete()
+        this.get_terminal().type(message).pause(1500).delete().go();
       }
     },
     get_terminal (){
-      return $('.k-status-bar span').typeIt(this.options)
+      return new TypeIt('.k-status-bar span', this.options);
     },
     /**
      * Display a message inside the k-status-bar.


### PR DESCRIPTION
Fix #3 
Cursor animation was using fading animation and it consumed too much CPU/GPU (15%-30%)

Updated the TypeIt library that uses CSS animation. The new blinking animation CPU/GPU usage is between 2%-5%