### PR TITLE
Remove javascript errors

### DIFF
--- a/src/components/kytos/switch/Interface.vue
+++ b/src/components/kytos/switch/Interface.vue
@@ -65,8 +65,9 @@ export default {
       return this.interface_id.split(":").slice(0,-1).join(":")
     },
     endpoint () {
-      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      return url + this.dpid + "/ports/" + Number(this.port_number)
+      // TODO: of_stats/kronos must implement the endpoint
+      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      //return url + this.dpid + "/ports/" + Number(this.port_number)
     },
     utilization_color_class: function () {
       if (this.speed === null) return ''
@@ -100,7 +101,8 @@ export default {
       }
     },
     update_chart() {
-      json(this.endpoint, this.parseInterfaceData)
+      // TODO: of_stats/kronos must implement the endpoint
+      //json(this.endpoint, this.parseInterfaceData)
     }
   },
   mounted () {

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -46,8 +46,9 @@ export default {
   },
   computed: {
     endpoint () {
-      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
+      // TODO: of_stats/kronos must implement the endpoint
+      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      //return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
     }
   },
   methods: {
@@ -81,7 +82,8 @@ export default {
         return endpoint_url;
     },
     update_chart() {
-        json(this.build_url(), this.parseInterfaceData)
+        // TODO: of_stats/kronos must implement the endpoint
+        //json(this.build_url(), this.parseInterfaceData)
     },
     change_plotRange(range) {
         this.plotRange = range

--- a/src/kytos/switchRadar.vue
+++ b/src/kytos/switchRadar.vue
@@ -39,13 +39,15 @@ export default {
   },
   computed: {
     endpoint () {
-      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      return url + this.dpid + "/ports"
+      // TODO: of_stats/kronos must implement the endpoint
+      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      //return url + this.dpid + "/ports"
     }
   },
   methods: {
     updateChart () {
-      json(this.endpoint, this.parseData)
+      // TODO: of_stats/kronos must implement the endpoint
+      // json(this.endpoint, this.parseData)
     },
     parseData (data) {
       if (!data) {


### PR DESCRIPTION
Fix #5 
In UI there are many javascript errors and message errors in kytos console.
These errors are related to the NApp of_stats where the REST calls were removed. New implementation using Kronos is not finished.
This PR remove/comment the REST calls to of_stats, leaving a TODO tag to remember the future implementation.