### PR TITLE
Added a metadata table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,6 @@ UNRELEASED - Under development
 ******************************
 Added
 =====
--Added active, enabled, lldp, nni and uni items to ``kytos/interfaceInfo`` to be displayed in basic details
--Added a table to ``kytos/interfaceInfo`` to be displayed interface metadata
 
 Changed
 =======
@@ -27,6 +25,14 @@ Security
 
 Changed
 =======
+
+[2022.2.0.b0] - 2022-04-07
+**************************
+
+Added
+=====
+-Added active, enabled, lldp, nni and uni items to ``kytos/interfaceInfo`` to be displayed in basic details
+-Added a table to ``kytos/interfaceInfo`` to be displayed interface metadata
 
 [2022.1.1] - 2022-03-14
 **********************************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ UNRELEASED - Under development
 ******************************
 Added
 =====
+-Added active, enabled, lldp, nni and uni items to ``kytos/interfaceInfo`` to be displayed in basic details
+-Added a table to ``kytos/interfaceInfo`` to be displayed interface metadata
 
 Changed
 =======

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2022.1.1",
+  "version": "2022.2.0.b0",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/switch/Interface.vue
+++ b/src/components/kytos/switch/Interface.vue
@@ -89,8 +89,9 @@ export default {
       return this.interface_id.split(":").slice(0,-1).join(":")
     },
     endpoint () {
-      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      return url + this.dpid + "/ports/" + Number(this.port_number)
+      // TODO: of_stats/kronos must implement the endpoint
+      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      //return url + this.dpid + "/ports/" + Number(this.port_number)
     },
     utilization_color_class: function () {
       if (this.speed === null) return ''
@@ -124,7 +125,8 @@ export default {
       }
     },
     update_chart() {
-      json(this.endpoint, this.parseInterfaceData)
+      // TODO: of_stats/kronos must implement the endpoint
+      //json(this.endpoint, this.parseInterfaceData)
     }
   },
   mounted () {

--- a/src/components/kytos/switch/Interface.vue
+++ b/src/components/kytos/switch/Interface.vue
@@ -50,6 +50,30 @@ export default {
     interface_id: {
       type: String,
       required: true,
+    },
+    enabled: {
+      type: Boolean,
+      required: true,
+    },
+    active: {
+      type: Boolean,
+      required: true,
+    },
+    lldp: {
+      type: Boolean,
+      required: true,
+    },
+    nni: {
+      type: Boolean,
+      required: true,
+    },
+    uni: {
+      type: Boolean,
+      required: true,
+    },
+    metadata: {
+      type: Object,
+      required: false,
     }
   },
   data () {
@@ -65,9 +89,8 @@ export default {
       return this.interface_id.split(":").slice(0,-1).join(":")
     },
     endpoint () {
-      // TODO: of_stats/kronos must implement the endpoint
-      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      //return url + this.dpid + "/ports/" + Number(this.port_number)
+      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      return url + this.dpid + "/ports/" + Number(this.port_number)
     },
     utilization_color_class: function () {
       if (this.speed === null) return ''
@@ -101,8 +124,7 @@ export default {
       }
     },
     update_chart() {
-      // TODO: of_stats/kronos must implement the endpoint
-      //json(this.endpoint, this.parseInterfaceData)
+      json(this.endpoint, this.parseInterfaceData)
     }
   },
   mounted () {

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -71,8 +71,9 @@ export default {
   },
   computed: {
     endpoint () {
-      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
+      // TODO: of_stats/kronos must implement the endpoint
+      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      //return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
     }
   },
   methods: {
@@ -106,7 +107,8 @@ export default {
         return endpoint_url;
     },
     update_chart() {
-        json(this.build_url(), this.parseInterfaceData)
+        // TODO: of_stats/kronos must implement the endpoint
+        //json(this.build_url(), this.parseInterfaceData)
     },
     change_plotRange(range) {
         this.plotRange = range

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -141,4 +141,38 @@ export default {
 </script>
 <style lang="sass">
 @import '../assets/styles/variables'
+
+.metadata_table 
+  color: #ccc
+  max-height: 250px
+  text-align: center
+  margin: 0 auto
+  display: block
+  padding: 0.5em 0 1em 0.3em
+  font-size: 0.8em
+  overflow-x: hidden
+  overflow-y: auto
+
+.metadata_table table
+  display: table
+  width: 100%
+
+.metadata_table thead
+  font-weight: bold
+  background: #554077
+
+.metadata_table th
+  padding: 0.6em 0 0.6em 0
+
+.metadata_table td
+  vertical-align: middle
+  padding: 0.45em 0 0.45em 0
+  word-break: break-all
+
+.metadata_table tbody tr:nth-child(even)
+  background: #313131
+
+.metadata_table tbody tr:hover
+    color: #eee
+    background-color: #666
 </style>

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -19,6 +19,25 @@
           </k-property-panel>
       </k-accordion-item>
 
+      <k-accordion-item title="Metadata" v-if="Object.keys(this.metadata_items).length !== 0">
+         <div class="metadata_table">
+            <table>
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Value</th>  
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(value, key) in this.metadata_items">
+                  <td >{{key}}</td>
+                  <td >{{value}}</td>
+                </tr>
+              </tbody>
+            </table>
+         </div>
+      </k-accordion-item>
+
     </k-accordion>
 </template>
 
@@ -33,12 +52,18 @@ export default {
   data () {
     return {
       display: false,
-      metadata: {"interface_id": "",
+      metadata_items: [],
+      metadata: {"enabled": "",
+                 "active": "",
+                 "interface_id": "",
                  "name": "",
                  "port_number": "",
                  "dpid": "",
                  "mac": "",
-                 "speed": ""},
+                 "speed": "",
+                 "lldp": "",
+                 "nni": "",
+                 "uni": "",},
       chartJsonData: null,
       interval: null,
       plotRange: null
@@ -46,9 +71,8 @@ export default {
   },
   computed: {
     endpoint () {
-      // TODO: of_stats/kronos must implement the endpoint
-      //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
-      //return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
+      let url = this.$kytos_server_api + "kytos/of_stats/v1/"
+      return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
     }
   },
   methods: {
@@ -82,18 +106,22 @@ export default {
         return endpoint_url;
     },
     update_chart() {
-        // TODO: of_stats/kronos must implement the endpoint
-        //json(this.build_url(), this.parseInterfaceData)
+        json(this.build_url(), this.parseInterfaceData)
     },
     change_plotRange(range) {
         this.plotRange = range
         this.update_chart()
+    },
+    get_metadata() {
+      if(this.content === undefined) return
+      this.metadata_items = this.content.metadata
     }
   },
   mounted () {
     this.update_interface_content()
     this.update_chart()
     this.interval = setInterval(this.update_chart, 60000)
+    this.get_metadata()
   },
   beforeDestroy () {
     clearInterval(this.interval)
@@ -103,13 +131,12 @@ export default {
       if (this.content) {
         this.update_interface_content()
         this.update_chart()
+        this.get_metadata()
       }
     }
   }
 }
 </script>
 <style lang="sass">
-
 @import '../assets/styles/variables'
-
 </style>


### PR DESCRIPTION
Base of Issue #13 
Added a metadata table
Added active, enabled, lldp, nni and uni items to display.
This pull request depends on changes to [k-info-panel/switch_info.kytos](https://github.com/kytos-ng/topology/blob/master/ui/k-info-panel/switch_info.kytos). Especifically:
From lines 18 to 19:
```
         <k-interface :interface_id="interface.id" :name="interface.name" :port_number="interface.port_number" :mac="interface.mac" 
                      :speed="interface.speed" :key="interface.name" v-for="interface in this.interfaces">
```
to Lines 18 to 20:
```
         <k-interface :interface_id="interface.id" :name="interface.name" :port_number="interface.port_number" :mac="interface.mac" 
                      :speed="interface.speed" :key="interface.name" :enabled="interface.enabled" :metadata="interface.metadata"
                      :active="interface.active" :lldp="interface.lldp" :nni="interface.nni" :uni="interface.uni" v-for="interface in this.interfaces">
```