### PR TITLE
Fix Select component event trigger

### DIFF
--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -61,32 +61,24 @@ export default {
       this.action(this.selected)
     }
   },
-  mounted () {
-    let _selected = [];
-    this.options.forEach((item) => {
-      if(item.selected) {
-        _selected.push(item.value);
-      }
-    });
-    this.selected = _selected;
+  beforeMount () {
+    // Initialize the selected values with the :value.sync property
+    if(this.value) {
+      let _selected = [];
+      this.value.forEach((item) => {
+        if(!this.selected.includes(item)) {
+          _selected.push(item);
+        }
+      });
+      this.selected = _selected;
+    }
   },
   watch: {
     selected () {
       this.emitEvent();
     },
-    options () {
-      let _selected = [];
-      this.options.forEach((item) => {
-        if(item.selected) {
-          _selected.push(item.value);
-        }
-      });
-      this.selected = _selected;
-    }
   }
 }
-
-
 </script>
 
 <style lang="sass">

--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -6,7 +6,7 @@
     </div>
     <select class="k-select__select" v-model="selected" @change.prevent="emitEvent"  multiple>
       <option v-for="item in options":value="item.value">
-        {{item.description}}
+        {{item.description}} 
       </option>
     </select>
    </label>
@@ -22,6 +22,7 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
  *
  * @example <k-select icon="link" title="Undesired links:" :options="get_links" :value.sync ="undesired_links"></k-select>
  * @example /_static/imgs/components/input/k-select.png
+ * 
  */
 
 export default {
@@ -61,19 +62,26 @@ export default {
     }
   },
   mounted () {
+    let _selected = [];
     this.options.forEach((item) => {
-      this.selected.push(item)
-    })
+      if(item.selected) {
+        _selected.push(item.value);
+      }
+    });
+    this.selected = _selected;
   },
   watch: {
     selected () {
-      this.emitEvent()
+      this.emitEvent();
     },
     options () {
+      let _selected = [];
       this.options.forEach((item) => {
-
-        this.selected.push(item);
-      })
+        if(item.selected) {
+          _selected.push(item.value);
+        }
+      });
+      this.selected = _selected;
     }
   }
 }


### PR DESCRIPTION
In the Select component, when the user selects multiple items, the event trigger fills the selected variable multiple times, creating a huge array.
This PR corrects this behavior and populates the selected variable with only selected items.