### PR TITLE
Change topology node label

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added
 
 Changed
 =======
+- Changed topology graph to display ``metadata.node_name`` as a default value. If node_name is not defined, display the datapath-id
 
 Deprecated
 ==========

--- a/src/components/kytos/topology/Topology.vue
+++ b/src/components/kytos/topology/Topology.vue
@@ -27,7 +27,7 @@ export default {
       strokes: {interface: 0, link: 1, host: 1},
       // other attributes
       labels_display: {
-        switch: 'name'
+        switch: 'node_name'
       }
     }
   },
@@ -484,6 +484,7 @@ export default {
       // only labeling switches, but not interfaces
       switch_labeled_items = gnodes.filter(function(d) {return d.type == "switch" || d.type == "iep";})
 
+      this.add_label("switch", "node_name", switch_labeled_items, true) // METADATA.NODE_NAME LABEL
       this.add_label("switch", "name", switch_labeled_items, true) // NAME LABEL
       this.add_label("switch", "description", switch_labeled_items, false)// DPID LABEL
       this.add_label("switch", "connection", switch_labeled_items, false)// ADDRESS LABEL

--- a/src/components/kytos/topology/Topology.vue
+++ b/src/components/kytos/topology/Topology.vue
@@ -379,9 +379,10 @@ export default {
             .style("fill", "rgba(155,155,255,0.2)")
 
       // adding the attribute itself as a svg text element
+      // fallback to 'name' attribute
       var label_text = label_group
           .append("text")
-            .text(function(d){ return d[attribute] })
+            .text(function(d){ return d[attribute] || d['name'] })
 
       // fixing the rect width and height according to the attribute size.
       label_rects


### PR DESCRIPTION
Closes #45 
Closes Topology issue [#127 ](https://github.com/kytos-ng/topology/issues/127)

**Summary**
Change topology graph to display metadata.node_name as a default value.
If node_name is not defined, display the datapath-id

**Local test**

- Select a node switch from the topology graph.
- Add a {"node_name": "value"} to the switch metadata.
- Verify that you can change the node label by selecting the attribute in the left dropdown component.
 ![image](https://github.com/kytos-ng/ui/assets/10867136/05641834-b289-4fd7-9686-1224eb809579)

