### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,27 +6,12 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
-Added
-=====
+[2023.1.0] - 2023-06-05
+***********************
 
 Changed
 =======
 - Changed topology graph to display ``metadata.node_name`` as a default value. If node_name is not defined, display the datapath-id
-
-Deprecated
-==========
-
-Removed
-=======
-
-Fixed
-=====
-
-Security
-========
-
-Changed
-=======
 
 [2023.1.0-b1] - 2023-05-03
 **************************

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2023.1.0-b1",
+  "version": "2023.1.0",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

N/A
