### PR TITLE
Add clear() to dropdown and select components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Added
 
 Changed
 =======
+
+- Added clear and reset functions to  ``components/kytos/inputs/Dropdown`` component
+- Added clear function to ``components/kytos/inputs/Select`` component
 - Changed topology graph to display ``metadata.node_name`` as a default value. If node_name is not defined, display the datapath-id
 
 Deprecated

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,6 @@ Added
 Changed
 =======
 
-- Added clear and reset functions to  ``components/kytos/inputs/Dropdown`` component
-- Added clear function to ``components/kytos/inputs/Select`` component
-- Changed topology graph to display ``metadata.node_name`` as a default value. If node_name is not defined, display the datapath-id
-
 Deprecated
 ==========
 
@@ -30,6 +26,17 @@ Security
 
 Changed
 =======
+
+
+[2023.1.0-b2] - 2023-06-22
+**************************
+
+Changed
+=======
+- Added clear and reset functions to  ``components/kytos/inputs/Dropdown`` component
+- Added clear function to ``components/kytos/inputs/Select`` component
+- Changed topology graph to display ``metadata.node_name`` as a default value. If node_name is not defined, display the datapath-id
+
 
 [2023.1.0-b1] - 2023-05-03
 **************************

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2023.1.0-b1",
+  "version": "2023.1.0-b2",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/inputs/Dropdown.vue
+++ b/src/components/kytos/inputs/Dropdown.vue
@@ -73,6 +73,9 @@ export default {
     },
     clear () {
       this.selected = '';
+    },
+    reset () {
+      this.selected = '';
       if(this.options && this.options.length > 0) {
         this.options.forEach((item) => {
           if (this.selected == '' && item.selected) {this.selected = item.value}

--- a/src/components/kytos/inputs/Dropdown.vue
+++ b/src/components/kytos/inputs/Dropdown.vue
@@ -70,6 +70,14 @@ export default {
       }
       this.$emit('update:value', this.selected)
       this.action(this.selected)
+    },
+    clear () {
+      this.selected = '';
+      if(this.options && this.options.length > 0) {
+        this.options.forEach((item) => {
+          if (this.selected == '' && item.selected) {this.selected = item.value}
+        })
+      }
     }
   },
   mounted () {

--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -59,6 +59,9 @@ export default {
       }
       this.$emit('update:value', this.selected)
       this.action(this.selected)
+    },
+    clear () {
+      this.selected = [];
     }
   },
   beforeMount () {


### PR DESCRIPTION
Add clear() function to dropdown component (single select) and select component (multiple select).
It resets the selected values to initial state or empty.