### PR TITLE
Input component tooltips now display properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Removed
 
 Fixed
 =====
+- Fixed tooltip for inputs not displaying
 
 Security
 ========

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="k-input-wrap">
     <icon v-if="icon" v-bind:name="iconName"></icon>
-    <input :value="value" :id="id" class="k-input" :tooltip="tooltip" :placeholder="placeholder"
+    <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
       ref="inputValue"
       v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="k-input-wrap">
-    <icon v-if="icon" v-bind:name="iconName"></icon>
+    <icon v-if="icon && iconName" :icon="iconName"></icon>
     <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
       ref="inputValue"


### PR DESCRIPTION
Closes #52 

### Summary

Fixed a bug that caused input component tooltips to not display.

This bug was due to the use of an incorrect HTML attribute. The attribute that generates a tooltip is the `title` attribute, while a `tooltip` attribute was used to try and generate a tooltip.

### Local Tests

I hovered my mouse over a `k-input` component and a tooltip was generated.

![image](https://github.com/kytos-ng/ui/assets/142065709/462b9a32-3202-47ae-963e-877bfda7de7c)

