### PR TITLE
fix UI button - remove 'this' from @click

### DIFF
--- a/src/components/kytos/inputs/buttons/Button.vue
+++ b/src/components/kytos/inputs/buttons/Button.vue
@@ -1,10 +1,9 @@
 <template>
   <button :id="id" class="k-button compact"
-    @click="this.handleClick"
+    @click="handleClick"
     v-bind:title="tooltip"
     v-bind:disabled="isDisabled">
       <icon v-if="icon && iconName" :icon="iconName"></icon>
-
       {{title}}
   </button>
 </template>
@@ -24,6 +23,7 @@ import KytosBaseWithIcon from '../../base/KytosBaseWithIcon';
 export default {
   name: 'k-button',
   mixins: [KytosBaseWithIcon],
+  emits: ['click'],
   methods: {
      /**
      * Call click event.


### PR DESCRIPTION
Closes #71 

### Summary
Fixed a bug on button components causing the @click event to fail.
This errors only occurs using the prod script to compile the UI.

### Local Tests
- Compile UI using `npm run prod` command
- Copy the build.js to the /kytos/web-ui/dist/build.js
- Click a node/switch on the map
- Click on the maximixe icon, or close icon

