### PR TITLE
Fix vue3 webpack prod script

### DIFF
--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -12,10 +12,16 @@ module.exports = merge(common,{
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: '"production"'
-      }
+      },
+      // explicity vue3 options
+      // https://vuejs.org/api/compile-time-flags.html
+      __VUE_OPTIONS_API__: 'true',
+      __VUE_PROD_DEVTOOLS__: 'false',
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false'
     }),
     new webpack.LoaderOptionsPlugin({
-      minimize: true
+      minimize: true,
+      debug: false
     }),
     new CleanWebpackPlugin(),
   ]


### PR DESCRIPTION
### Summary

Fix webpack prod script, adding explicity vue3 options to compile for production.

### Local Tests
- Install the NPM dependencies `npm i`
- Build the UI with production script `npm run prod `
- copy build.js to /kytos/web-ui/dist/build.js
- run kytosd
- access Kytos UI in the browser
- open developer console inside the browser
- Check if there is warning messages about the compatiblity mode with vue2

