### PR TITLE
Adds a cachebuster parameter to load build.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,12 @@
     <script>
       window.kytos_server = location.protocol + "//" + location.host + "/";
       window.kytos_server_api = location.protocol + "//" + location.host + "/api/";
+
+      // Load build.js with cachebuster parameter for 12 hours
+      const cachebuster = Math.round(new Date().getTime() / 43200000);
+      var el = document.createElement('script');
+      el.src = "/dist/build.js?v=" + cachebuster;
+      document.getElementsByTagName('head')[0].appendChild(el);
     </script>
-    <script src="/dist/build.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #75 

### Summary
Fix a problem with browser caching in the build.js request, which loads all javascript libraries.
The strategy was to include a "cache buster" parameter to invalidate the cache every 12 hours.

### Local Tests
- Edit the index.html file and change the parameter from 12hs to 5min
- Open kytos using any browser
- Open Developer Mode and check the ‘Network’ tab
- The first request to build.js should return HTTP code 200
- Subsequent requests should be HTTP 304 for about 5 minutes
- After 5 minutes, the request should be HTTP code 200

### End-to-End Tests
