### PR TITLE
Added Modal Component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,17 +6,16 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
-[2024.1.0-b1] - 2024-08-05
-***********************
-
 Added
 =====
 - Added new "k-modal" component.
 
+[2024.1.0-b1] - 2024-08-05
+***********************
+
 Changed
 =======
 - Upgraded Vue framework to Vue3 in compatibility mode.
-
 
 [2023.2.1] - 2024-06-04
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,9 +9,14 @@ UNRELEASED - Under development
 [2024.1.0-b1] - 2024-08-05
 ***********************
 
+Added
+=====
+- Added new "k-modal" component.
+
 Changed
 =======
 - Upgraded Vue framework to Vue3 in compatibility mode.
+
 
 [2023.2.1] - 2024-06-04
 ***********************

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@
     <k-info-panel></k-info-panel>
     <k-action-menu></k-action-menu>
     <k-napps-info-panel></k-napps-info-panel>
+    <k-modal message="There has been a grave mistake" header="Error" buttonTitle="Ok"></k-modal>
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,6 @@
     <k-info-panel></k-info-panel>
     <k-action-menu></k-action-menu>
     <k-napps-info-panel></k-napps-info-panel>
-    <k-modal message="There has been a grave mistake" header="Error" buttonTitle="Ok"></k-modal>
   </div>
 </template>
 

--- a/src/components/kytos/misc/Modal.vue
+++ b/src/components/kytos/misc/Modal.vue
@@ -14,9 +14,9 @@
                 </div>
                 <div class="modal-footer">
                     <slot name="footer">
-                        <k-button tooltip="Cancel" title="Cancel" @click.native="modalClose">
+                        <k-button tooltip="Cancel" title="Cancel" @click="modalClose">
                         </k-button>
-                        <k-button id="modalOK" :tooltip="buttonTitle" :title="buttonTitle" @click.native="invokeAction">
+                        <k-button id="modalOK" :tooltip="buttonTitle" :title="buttonTitle" @click="invokeAction">
                         </k-button>
                     </slot>
                 </div>

--- a/src/components/kytos/misc/Modal.vue
+++ b/src/components/kytos/misc/Modal.vue
@@ -41,11 +41,7 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 export default {
     name: 'k-modal',
     mixins: [KytosBaseWithIcon],
-    data() {
-        return {
-            showModal: true
-        }
-    },
+    emits: ['update:showModal'],
     props: {
         /**
          * String used in modal body
@@ -77,6 +73,13 @@ export default {
         action: {
             type: Function,
             required: false
+        },
+        /**
+         * Hides or displays modal
+         */
+        showModal: {
+            type: Boolean,
+            required: true
         }
     },
     methods: {
@@ -84,7 +87,7 @@ export default {
             /**
             * Modal window - Close (X) buttom
             */
-           this.showModal = false;
+           this.$emit('update:showModal', false)
         },
         invokeAction() {
             /**

--- a/src/components/kytos/misc/Modal.vue
+++ b/src/components/kytos/misc/Modal.vue
@@ -135,6 +135,8 @@ export default {
 
     .modal-body
         margin: 20px 0
+        word-wrap: break-word
+        overflow-wrap: break-word
 
     .modal-default-button
         float: right

--- a/src/components/kytos/misc/Modal.vue
+++ b/src/components/kytos/misc/Modal.vue
@@ -1,0 +1,157 @@
+<template>
+    <div class="modal-mask" v-if="showModal">
+        <div class="modal-wrapper">
+            <div class="modal-container">
+                <div class="modal-header">
+                    <slot name="header">
+                        {{ header }}
+                    </slot>
+                </div>
+                <div class="modal-body">
+                    <slot name="body">
+                        {{ message }}
+                    </slot>
+                </div>
+                <div class="modal-footer">
+                    <slot name="footer">
+                        <k-button tooltip="Cancel" title="Cancel" @click.native="modalClose">
+                        </k-button>
+                        <k-button id="modalOK" :tooltip="buttonTitle" :title="buttonTitle" @click.native="invokeAction">
+                        </k-button>
+                    </slot>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import KytosBase from '../base/KytosBase';
+import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
+
+/**
+ * A general modal element/component that allows you to define your own header, body, button, 
+ * and function to be executed when it's pressed.
+ * 
+ * @example
+ * //generates modal
+ * <k-modal message="There has been a grave mistake" header="Error" buttonTitle="Ok" action="Func"></k-modal>
+ */
+
+export default {
+    name: 'k-modal',
+    mixins: [KytosBaseWithIcon],
+    data() {
+        return {
+            showModal: true
+        }
+    },
+    props: {
+        /**
+         * String used in modal body
+         */
+        message: {
+            type: String,
+            required: false,
+            default: ""
+        },
+        /**
+         * String used in modal header/title
+         */
+        header: {
+            type: String,
+            required: false,
+            default: ""
+        },
+        /**
+         * Name of second button within modal
+         */
+        buttonTitle: {
+            type: String,
+            required: false,
+            default: "Ok"
+        },
+        /**
+         * Action to be done when second button is pressed
+         */
+        action: {
+            type: Function,
+            required: false
+        }
+    },
+    methods: {
+        modalClose() {
+            /**
+            * Modal window - Close (X) buttom
+            */
+           this.showModal = false;
+        },
+        invokeAction() {
+            /**
+             * Workaround to set a default function for modal
+             */
+            if (this.action) {
+                this.action();
+                this.modalClose();
+            } else {
+                this.modalClose();
+            }
+        }
+    }
+}
+</script>
+
+<style lang="sass">
+
+    @import '../../../assets/styles/variables'
+
+    .modal-mask
+        position: fixed
+        z-index: 9998
+        top: 0
+        left: 0
+        width: 100%
+        height: 100%
+        background-color: rgba(0, 0, 0, 0.5)
+        display: table
+        transition: opacity 0.3s ease
+
+    .modal-wrapper
+        display: table-cell
+        vertical-align: middle
+
+    .modal-container
+        width: 300px
+        margin: 0px auto
+        padding: 10px 10px 10px 20px
+        background-color: #e8e8e8
+        border-radius: 2px
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33)
+        transition: all 0.3s ease
+        font-family: Helvetica, Arial, sans-serif
+
+    .modal-body
+        margin: 20px 0
+
+    .modal-default-button
+        float: right
+
+    .modal-enter
+        opacity: 0
+
+    .modal-leave-active
+        opacity: 0
+
+    .modal-footer
+        justify-content: end
+        display: flex
+
+    #modalOK
+        color: #ffc5c5
+        background: #be0000
+
+    .modal-header
+        font-weight: bold
+        margin-top: 2%
+
+</style>

--- a/src/components/kytos/misc/Modal.vue
+++ b/src/components/kytos/misc/Modal.vue
@@ -35,7 +35,7 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
  * 
  * @example
  * //generates modal
- * <k-modal message="There has been a grave mistake" header="Error" buttonTitle="Ok" action="Func"></k-modal>
+ * <k-modal message="There has been a grave mistake" header="Error" buttonTitle="Ok" action="Func" v-model:show-modal="condition"></k-modal>
  */
 
 export default {

--- a/src/main.js
+++ b/src/main.js
@@ -38,6 +38,7 @@ import KytosButtonGroup from './components/kytos/inputs/buttons/ButtonGroup.vue'
 import KytosDropdown from './components/kytos/inputs/Dropdown.vue';
 import KytosContextPanel from './components/kytos/misc/ContextPanel.vue';
 import KytosMenubar from './components/kytos/misc/Menubar.vue';
+import KytosModal from './components/kytos/misc/Modal.vue';
 import KytosActionMenu from './components/kytos/misc/ActionMenu.vue';
 import KytosInfoPanel from './components/kytos/misc/InfoPanel.vue';
 import KytosStatusBar from './components/kytos/misc/StatusBar.vue';
@@ -77,6 +78,7 @@ library.add(fas, far, fab)
 dom.watch();
 
 kytos.component('k-menubar', KytosMenubar);
+Vue.component('k-modal', KytosModal);
 kytos.component('k-map', KytosMap);
 kytos.component('mapbox-settings', MapBoxSettings);
 kytos.component('k-topology', KytosTopology);

--- a/src/main.js
+++ b/src/main.js
@@ -78,7 +78,7 @@ library.add(fas, far, fab)
 dom.watch();
 
 kytos.component('k-menubar', KytosMenubar);
-Vue.component('k-modal', KytosModal);
+kytos.component('k-modal', KytosModal);
 kytos.component('k-map', KytosMap);
 kytos.component('mapbox-settings', MapBoxSettings);
 kytos.component('k-topology', KytosTopology);


### PR DESCRIPTION
Closes #N/A

### Summary

Added a reusable modal component to UI made from existing code. The component is called "k-modal".

![image](https://github.com/user-attachments/assets/99269f88-02ac-4df3-a8a3-dfd08ea68aeb)

### Local Tests

A combination of all parameters were used all at once to ensure functionality.

### Associated Pull Requests

#### Childs

Description - Repositories that implemented new modal component.

- https://github.com/kytos-ng/telemetry_int/pull/134
- https://github.com/kytos-ng/mef_eline/pull/507
- https://github.com/kytos-ng/topology/pull/210
- https://github.com/kytos-ng/maintenance/pull/92