### PR TITLE
UI Button Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2024.1.0-b2] - 2024-09-10
+***********************
+
+Fixed
+=======
+- Upgraded Vue framework to Vue3 in compatibility mode.
+
 [2024.1.0-b1] - 2024-08-05
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ UNRELEASED - Under development
 
 Fixed
 =======
-- Upgraded Vue framework to Vue3 in compatibility mode.
+- Fixed buttons within ``interfaceInfo.vue`` that were using old ``on_click``.
 
 [2024.1.0-b1] - 2024-08-05
 ***********************

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2024.1.0-b1",
+  "version": "2024.1.0-b2",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -64,7 +64,7 @@
         </div>
         <k-textarea title="Set tag_ranges" icon="arrow-right" placeholder="Eg. [[100, 200], [400, 4095]]" v-model:value="new_tag_ranges"></k-textarea>
         <div class="metadata_container">
-          <k-button title="Set tag_ranges" :on_click="set_tag_ranges"></k-button>
+          <k-button title="Set tag_ranges" @click="set_tag_ranges"></k-button>
         </div>
       </k-accordion-item>
       <k-accordion-item title="Metadata" v-if="Object.keys(this.metadata_items).length !== 0">


### PR DESCRIPTION
Closes #83 

### Summary

Some buttons were using the old `on_click `instead of the new `@click`. These buttons were updated accordingly to use the new `@click`. 

### Local Tests

The buttons were pressed and they functioned as should.
