### PR TITLE
fixed enter key handler on k-input-auto

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Added
 =====
 - Added new "k-modal" component.
 
+Changed
+=======
+- Fixed Enter key handler on InputAutocomplete (k-input-auto)
+
 [2024.1.0] - 2024-08-16
 ***********************
 

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -4,6 +4,7 @@
       :search="search"
       :placeholder="placeholder"
       :aria-label="label"
+      :submitOnEnter="true"
       class="autocomplete-wrap"
       @submit="handleSubmit"
     >


### PR DESCRIPTION
Closes #90

### Summary

See updated changelog file. Basically, recent versions of `@trevoreyre/autocomplete-vue` introduced a new option called `submitOnEnter`, which [prevents the input from properly updating the value of the input based on the chosen option](https://github.com/trevoreyre/autocomplete/blob/master/packages/autocomplete/AutocompleteCore.js#L80-L98) specially on our case which the options are typically [list items](https://github.com/trevoreyre/autocomplete/blob/master/packages/autocomplete/AutocompleteCore.js#L92).

### Local Tests

Example of using k-input-auto with recent fixes on mef_eline (https://github.com/kytos-ng/mef_eline/issues/518):

![Oct-07-2024 05-16-56](https://github.com/user-attachments/assets/95d05275-2709-4f2d-9bf1-c653fd590616)

### End-to-End Tests

N/A