### PR TITLE
adding confirmation modal when enabling/disabing interfaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ UNRELEASED - Under development
 Added
 =====
 - Added new "k-modal" component.
+- Added confirmation modal when enabling/disabling interfaces
 
 Changed
 =======

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -4,6 +4,31 @@
         <k-button tooltip="Go back to switch info" title="< Back to switch" @click="back_switch"></k-button>
         <k-button @click="bt_state_toggle" :title="next_state"></k-button>
       </div>
+      <template v-if="show_modal_state_toggle">
+        <div class="modal-mask">
+          <div class="modal-wrapper">
+            <div class="modal-container">
+              <div class="modal-header">
+                <slot name="header">
+                </slot>
+              </div>
+              <div class="modal-body">
+                <slot name="body">
+                  {{next_state}} Interface {{metadata_items.port_name !== undefined && metadata_items.port_name.length !== 0? metadata_items.port_name : metadata.interface_id}}?
+                </slot>
+              </div>
+              <div class="modal-footer">
+                <slot name="footer">
+                  <k-button tooltip="Cancel" title="Cancel" @click="modal_cancel_state_toggle">
+                  </k-button>
+                  <k-button id="modal-delete" :title="next_state" @click="modal_proceed_state_toggle">
+                  </k-button>
+                </slot>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
       <k-accordion-item title="Interface Plot" v-if="chartJsonData">
         <k-button-group>
             <!-- input type="text" class="k-input" placeholder="Zoom" disabled -->
@@ -132,6 +157,7 @@ export default {
       new_tag_type: "",
       tag_ranges: {},
       available_tags: {},
+      show_modal_state_toggle: false,
       content_switch: []
     }
   },
@@ -200,6 +226,16 @@ export default {
       this.next_state = this.metadata.enabled == 'true'? 'Disable' : 'Enable'
     },
     bt_state_toggle: function() {
+      this.show_modal_state_toggle = true;
+    },
+    modal_cancel_state_toggle(){
+      this.show_modal_state_toggle = false;
+    },
+    modal_proceed_state_toggle(){
+      this.show_modal_state_toggle = false;
+      this.state_toggle_interface();
+    },
+    state_toggle_interface(){
       var _this = this
       let request = $.ajax({
                        type:"POST",

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -4,31 +4,12 @@
         <k-button tooltip="Go back to switch info" title="< Back to switch" @click="back_switch"></k-button>
         <k-button @click="bt_state_toggle" :title="next_state"></k-button>
       </div>
-      <template v-if="show_modal_state_toggle">
-        <div class="modal-mask">
-          <div class="modal-wrapper">
-            <div class="modal-container">
-              <div class="modal-header">
-                <slot name="header">
-                </slot>
-              </div>
-              <div class="modal-body">
-                <slot name="body">
-                  {{next_state}} Interface {{metadata_items.port_name !== undefined && metadata_items.port_name.length !== 0? metadata_items.port_name : metadata.interface_id}}?
-                </slot>
-              </div>
-              <div class="modal-footer">
-                <slot name="footer">
-                  <k-button tooltip="Cancel" title="Cancel" @click="modal_cancel_state_toggle">
-                  </k-button>
-                  <k-button id="modal-delete" :title="next_state" @click="modal_proceed_state_toggle">
-                  </k-button>
-                </slot>
-              </div>
-            </div>
-          </div>
-        </div>
-      </template>
+      <k-modal
+        :message="modal_state_toggle_message"
+        :button-title="next_state"
+        :action="state_toggle_interface"
+        v-model:show-modal="show_modal_state_toggle">
+      </k-modal>
       <k-accordion-item title="Interface Plot" v-if="chartJsonData">
         <k-button-group>
             <!-- input type="text" class="k-input" placeholder="Zoom" disabled -->
@@ -166,7 +147,10 @@ export default {
       // TODO: of_stats/kronos must implement the endpoint
       //let url = this.$kytos_server_api + "kytos/of_stats/v1/"
       //return url + this.metadata.dpid + "/ports/" + this.metadata.port_number
-    }
+    },
+    modal_state_toggle_message() {
+       return `${this.next_state} Interface ${this.metadata_items.port_name !== undefined && this.metadata_items.port_name.length !== 0 ? '"' + this.metadata_items.port_name + '"' : this.metadata.interface_id}?`
+    },
   },
   methods: {
     update_interface_content: function() {
@@ -228,13 +212,6 @@ export default {
     bt_state_toggle: function() {
       this.show_modal_state_toggle = true;
     },
-    modal_cancel_state_toggle(){
-      this.show_modal_state_toggle = false;
-    },
-    modal_proceed_state_toggle(){
-      this.show_modal_state_toggle = false;
-      this.state_toggle_interface();
-    },
     state_toggle_interface(){
       var _this = this
       let request = $.ajax({
@@ -249,8 +226,7 @@ export default {
           icon: 'cog',
         }
         _this.next_state = _this.next_state == 'Enable'? 'Disable' : 'Enable'
-        _this.content['enabled'] = _this.next_state == 'Enable'? 'false' : 'true'
-        _this.metadata['enabled'] = _this.content['enabled']
+        _this.metadata['enabled'] = _this.next_state == 'Enable'? 'false' : 'true'
         _this.$kytos.eventBus.$emit("setNotification", notification)
       });
       request.fail(function(data) {


### PR DESCRIPTION
Closes #62 

Closes #94

Heads-up: this PR sits on top of PR #91 

### Summary

See updated changelog file.

### Local Tests

After applying this fix (along with https://github.com/kytos-ng/topology/pull/218):

![Oct-07-2024 10-19-25](https://github.com/user-attachments/assets/aa18c2de-91e0-4ef8-9a7a-84e5c8701d21)


### End-to-End Tests

N/A