### PR TITLE
hotfix into 2024.1 - fixed enter key handler on k-input-auto

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2024.1.1] - 2024-10-07
+***********************
+
+Changed
+=======
+ - Fixed Enter key handler on InputAutocomplete (k-input-auto)
+
 [2024.1.0] - 2024-08-16
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -4,6 +4,7 @@
       :search="search"
       :placeholder="placeholder"
       :aria-label="label"
+      :submitOnEnter="true"
       class="autocomplete-wrap"
       @submit="handleSubmit"
     >


### PR DESCRIPTION
Closes #92 

### Summary

See updated changelog file.

### Local Tests

Same as described on https://github.com/kytos-ng/ui/pull/91 to run the tests:

```
git clone https://github.com/kytos-ng/ui kytos-ui
cd kytos-ui
docker run -d --name kytos-ui -v $(PWD):/kytos-ui -w /kytos-ui node:lts-alpine tail -f /dev/null
docker exec -it kytos-ui sh
apk add zip
## if you running this multi time, you may want to have a clean start: rm -rf latest.zip dist package-lock.json node_modules/
npm install
npm run build
## you can also run this to have a running code in debug mode (to help dev): npm run preprod && zip -r latest.zip index.html dist
exit

# copy the latest.zip file into Kytos installation
mv /usr/local/lib/python3.11/dist-packages/kytos/web-ui /usr/local/lib/python3.11/dist-packages/kytos/web-ui-$(date +%Y%m%d%H%M)
python3 -m zipfile -e latest.zip /usr/local/lib/python3.11/dist-packages/kytos/web-ui
```

![Oct-07-2024 15-22-00](https://github.com/user-attachments/assets/b948c6d9-8f0e-46f4-898b-ceaf75585108)

### End-to-End Tests

N/A