### PR TITLE
backport/hotfix for issue #93 into 2023.2 -- fixed enter key handler on k-input-auto

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2023.2.2] - 2024-10-07
+***********************
+
+Changed
+=======
+- Fixed Enter key handler on InputAutocomplete (k-input-auto)
+
 [2023.2.1] - 2024-06-04
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2023.2.1",
+  "version": "2023.2.2",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -4,6 +4,7 @@
       :search="search"
       :placeholder="placeholder"
       :aria-label="label"
+      :submitOnEnter="true"
       class="autocomplete-wrap"
       @submit="handleSubmit"
     >


### PR DESCRIPTION
Closes #93

### Summary

See updated changelog file.

### Local Tests

After applying this fix along with https://github.com/kytos-ng/mef_eline/pull/533:

![Oct-07-2024 16-04-36](https://github.com/user-attachments/assets/f0867148-de18-42e3-8ecb-c46cf9390d1e)

### End-to-End Tests

N/A