### PR TITLE
Backport/hotfix for 2024.1.1 -- interface enabling/disabling confirmation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
-[2024.1.1] - 2024-10-07
+[2024.1.1] - 2024-10-08
 ***********************
 
 Changed
 =======
  - Fixed Enter key handler on InputAutocomplete (k-input-auto)
+ - [backport] Added confirmation modal when enabling/disabling interfaces
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -4,6 +4,31 @@
         <k-button tooltip="Go back to switch info" title="< Back to switch" @click="back_switch"></k-button>
         <k-button @click="bt_state_toggle" :title="next_state"></k-button>
       </div>
+      <template v-if="show_modal_state_toggle">
+        <div class="modal-mask">
+          <div class="modal-wrapper">
+            <div class="modal-container">
+              <div class="modal-header">
+                <slot name="header">
+                </slot>
+              </div>
+              <div class="modal-body">
+                <slot name="body">
+                  {{next_state}} Interface {{metadata_items.port_name !== undefined && metadata_items.port_name.length !== 0? metadata_items.port_name : metadata.interface_id}}?
+                </slot>
+              </div>
+              <div class="modal-footer">
+                <slot name="footer">
+                  <k-button tooltip="Cancel" title="Cancel" @click="modal_cancel_state_toggle">
+                  </k-button>
+                  <k-button id="modal-delete" :title="next_state" @click="modal_proceed_state_toggle">
+                  </k-button>
+                </slot>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
       <k-accordion-item title="Interface Plot" v-if="chartJsonData">
         <k-button-group>
             <!-- input type="text" class="k-input" placeholder="Zoom" disabled -->
@@ -132,7 +157,8 @@ export default {
       new_tag_type: "",
       tag_ranges: {},
       available_tags: {},
-      content_switch: []
+      content_switch: [],
+      show_modal_state_toggle: false,
     }
   },
   computed: {
@@ -200,6 +226,16 @@ export default {
       this.next_state = this.metadata.enabled == 'true'? 'Disable' : 'Enable'
     },
     bt_state_toggle: function() {
+      this.show_modal_state_toggle = true;
+    },
+    modal_cancel_state_toggle: function(){
+      this.show_modal_state_toggle = false;
+    },
+    modal_proceed_state_toggle: function(){
+      this.show_modal_state_toggle = false;
+      this.state_toggle_interface();
+    },
+    state_toggle_interface: function(){
       var _this = this
       let request = $.ajax({
                        type:"POST",
@@ -213,8 +249,7 @@ export default {
           icon: 'cog',
         }
         _this.next_state = _this.next_state == 'Enable'? 'Disable' : 'Enable'
-        _this.content['enabled'] = _this.next_state == 'Enable'? 'false' : 'true'
-        _this.metadata['enabled'] = _this.content['enabled']
+        _this.metadata['enabled'] = _this.next_state == 'Enable'? 'false' : 'true'
         _this.$kytos.eventBus.$emit("setNotification", notification)
       });
       request.fail(function(data) {


### PR DESCRIPTION
Closes #97 

### Summary

See updated changelog file.

### Local Tests

After applying this fix:

![Oct-08-2024 14-23-59](https://github.com/user-attachments/assets/45a0ad15-6196-4f73-9ea0-f5ff5a9cb0f7)


### End-to-End Tests
