### PR TITLE
Changes for Vue Upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,13 @@ Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
 - MenuBar now clears Infopanels before switching to a new item for better visibility.
+- Replaced listeners with attrs
+- Replaced value with modelValue
+- Replaced the use of Vue and new Vue with the app instace
+
+Fixed
+=======
+- Fixed icon v-bind within StatusMenu
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="k-input-wrap">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
-    <input :value="modelValue" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
+    <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
       ref="inputValue"
       v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>
@@ -28,9 +28,9 @@ export default {
    /**
     * The value to input button.
     */
-   modelValue: {
+   value: {
       type: String,
-      default: ""
+      default: "l"
    },
    /*
    * Tooltip string for the input.
@@ -50,12 +50,12 @@ export default {
    action: {
       type: Function,
       default: function(val) {return}
-   },
-   emits: ['update:modelValue']
+   }
   },
+  emits: ['update:value'],
   methods: {
     updateText(){
-      this.$emit('update:modelValue', this.$refs.inputValue.value)
+      this.$emit('update:value', this.$refs.inputValue.value)
       this.action(this.$refs.inputValue.value)
     }
   }

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -30,7 +30,7 @@ export default {
     */
    value: {
       type: String,
-      default: "l"
+      default: ""
    },
    /*
    * Tooltip string for the input.

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="k-input-wrap">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
-    <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
+    <input :value="modelValue" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
       ref="inputValue"
       v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>
@@ -21,11 +21,14 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 export default {
   name: 'k-input',
   mixins: [KytosBaseWithIcon],
+  compatConfig: {
+    MODE: 3,
+  },
   props: {
    /**
     * The value to input button.
     */
-   value: {
+   modelValue: {
       type: String,
       default: ""
    },
@@ -47,11 +50,12 @@ export default {
    action: {
       type: Function,
       default: function(val) {return}
-   }
+   },
+   emits: ['update:modelValue']
   },
   methods: {
     updateText(){
-      this.$emit('update:value', this.$refs.inputValue.value)
+      this.$emit('update:modelValue', this.$refs.inputValue.value)
       this.action(this.$refs.inputValue.value)
     }
   }

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -96,6 +96,9 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
  * @example /_static/imgs/components/input/k-input-auto.png
  */
 var CustomInput = {
+  compatConfig: {
+    MODE: 3,
+  },
   props: {
     value: {
       type: String,
@@ -130,8 +133,8 @@ var CustomInput = {
       type: String,
       default: ""
    }
-  }, 
-  template: '<input :id="id" class="k-input" :tooltip="tooltip" ref="inputValue" :placeholder="placeholder" :value="value" v-on="$listeners" />'
+  },
+  template: '<input :id="id" class="k-input" :tooltip="tooltip" ref="inputValue" :placeholder="placeholder" :value="value" v-bind="$attrs" />'
 }
 
 export default {

--- a/src/components/kytos/logging/Logging.vue
+++ b/src/components/kytos/logging/Logging.vue
@@ -14,7 +14,7 @@
           <k-button title="Debug" @click="select('debug')"  tooltip="Only debug messages"></k-button>
         </k-button-group>
         <k-button-group>
-          <k-input v-model="highlight_string" v-on:change='highlight' icon="lightbulb" tooltip="Highlight string" placeholder="Highlight string"></k-input>
+          <k-input v-model:value="highlight_string" v-on:change='highlight' icon="lightbulb" tooltip="Highlight string" placeholder="Highlight string"></k-input>
         </k-button-group>
       </div>
 

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -2,7 +2,7 @@
   <k-toolbar-item icon="signal" tooltip="Status Menu">
     <div class="k-status-menu">
       <div class="k-status-title">
-        <icon :icon="signal"></icon>
+        <icon icon="signal"></icon>
         <div class="panel-title">
           <h1> Status Menu </h1>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ const kytos = createApp({
   },
 })
 
-Vue.use(VueHotkey)
+kytos.use(VueHotkey)
 
 window.$ = window.jQuery = require('jquery');
 window.d3 = window.D3 = require('d3');
@@ -125,7 +125,7 @@ kytos.component('k-notification', KytosNotification)
 // Preserve extra whitespaces
 kytos.config.compilerOptions.whitespace = 'preserve';
 
-kytos.config.globalProperties.$kytos = new Vue()
+kytos.config.globalProperties.$kytos = kytos
 kytos.config.globalProperties.$kytos_server = window.kytos_server
 kytos.config.globalProperties.$kytos_server_api =  window.kytos_server_api
 kytos.config.globalProperties.$kytos_version = version


### PR DESCRIPTION
Closes #107
Closes #106

Partially deals with #85 but the toolbar still uses Vue instead of app instance to register components with the httpvueloader.

### Summary

I updated the input `v-model` to use the new syntax.
I replaced `$listerners` with `$attrs` in the auto complete component.
I replaced the Vue and new Vue with the app instance in `main.js`.


### Local Tests

The warnings were removed from the console.
The UI still functioned as should.
