### PR TITLE
Replace httpvueloader with vue3-sfc-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "write-file": "^1.0.0"
   },
   "devDependencies": {
+    "vue3-sfc-loader": "^0.9.5",
     "@vue/compiler-sfc": "^3.1.0",
     "clean-webpack-plugin": "^4.0.0",
     "cross-env": "^7.0.3",

--- a/src/components/kytos/accordion/AccordionItem.vue
+++ b/src/components/kytos/accordion/AccordionItem.vue
@@ -35,13 +35,9 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 export default {
   name: 'k-accordion-item',
   mixins: [KytosBaseWithIcon],
-  props:{
-    /**
-    * Boolean value to represent whether the accordion item is checked.
-    */
-    checked: {
-      type: Boolean,
-      default: true
+  data () {
+    return {
+      checked: true
     }
   }
 }

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -44,6 +44,13 @@ export default {
       type: String
    },
    /**
+    * If true disables the input functionality of the input component (used for display purposes).
+    */
+   isDisabled: {
+      type: Boolean,
+      default: false
+   },
+   /**
    * Function called after input changes.
    */
    action: {

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -29,7 +29,6 @@ export default {
     * The value to input button.
     */
    value: {
-      type: String,
       default: ""
    },
    /*

--- a/src/components/kytos/napp/ActionMenuItem.vue
+++ b/src/components/kytos/napp/ActionMenuItem.vue
@@ -43,7 +43,7 @@ const options = {
     const res = await fetch(url);
     if (!res.ok)
       throw Object.assign(new Error(url + ' ' + res.statusText), { res });
-    return await res.text();
+    return await {type: '.vue', getContentData: ()=>res.text()};
   },
 
   addStyle(textContent) {

--- a/src/components/kytos/napp/ActionMenuItem.vue
+++ b/src/components/kytos/napp/ActionMenuItem.vue
@@ -32,7 +32,7 @@ const options = {
         options.addStyle(await getContentData(false));
         return null;
       case '.kytos':
-        console.log("Kytos detected");
+        console.log("Kytos extension detected. Switch extension to .vue");
         return null;
       default: return undefined; // let vue3-sfc-loader handle this
     }

--- a/src/components/kytos/napp/ActionMenuItem.vue
+++ b/src/components/kytos/napp/ActionMenuItem.vue
@@ -6,7 +6,60 @@
 
 <script>
 import Vue from 'vue'
-import httpVueLoader from "./httpVueLoader.js"
+import { loadModule } from "vue3-sfc-loader"
+ 
+const options = {
+
+  moduleCache: {
+    vue: Vue
+  },
+
+  pathResolve({ refPath, relPath }, options) {
+
+    if (relPath === '.')
+      return refPath;
+
+    if (relPath[0] !== '.' && relPath[0] !== '/')
+      return relPath;
+
+    return String(new URL(relPath, refPath === undefined ? window.location : refPath));
+  },
+
+  handleModule: async function (type, getContentData, path, options) {
+
+    switch (type) {
+      case '.css':
+        options.addStyle(await getContentData(false));
+        return null;
+      case '.kytos':
+        console.log("Kytos detected");
+        return null;
+      default: return undefined; // let vue3-sfc-loader handle this
+    }
+  },
+
+  async getFile(url) {
+
+    const res = await fetch(url);
+    if (!res.ok)
+      throw Object.assign(new Error(url + ' ' + res.statusText), { res });
+    return await res.text();
+  },
+
+  addStyle(textContent) {
+
+    const style = Object.assign(document.createElement('style'), { textContent });
+    const ref = document.head.getElementsByTagName('style')[0] || null;
+    document.head.insertBefore(style, ref);
+  },
+
+  log(type, ...args) {
+
+    console.log("vue3-sfc-loader log:");
+    console[type](...args);
+  }
+
+}
 
 export default {
   name: 'k-action-menu-item',
@@ -36,8 +89,8 @@ export default {
       $.each(self.components, function(index, component){
         if('url' in component){
           // random is needed to avoid cache of components.
-          var url = self.$kytos_server+component.url+"?random="+Math.random()
-          Vue.component(component.name, httpVueLoader(url))
+          var url = self.$kytos_server+component.url
+          self.$kytos.component(component.name, Vue.defineAsyncComponent( () => loadModule(url, options) ))
         }
       })
     },

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -43,7 +43,7 @@ const options = {
    const res = await fetch(url);
    if ( !res.ok )
       throw Object.assign(new Error(url+' '+res.statusText), { res });
-   return await res.text();
+   return await {type: '.vue', getContentData: ()=>res.text()};
  },
 
  addStyle(textContent) {

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -32,7 +32,7 @@ const options = {
       options.addStyle(await getContentData(false));
       return null;
     case '.kytos':
-      console.log("Kytos detected");
+      console.log("Kytos extension detected. Switch extension to .vue");
       return null;
     default: return undefined; // let vue3-sfc-loader handle this
   }

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -25,11 +25,11 @@ export default {
         cache: false,
         success: function(data) {
           if(data) {
-            self.components = self.components.concat(data)
+            //self.components = self.components.concat(data)
           }
         }
       }).always(function(){
-          self.load_components()
+          //self.load_components()
       })
   },
   methods: {
@@ -39,7 +39,7 @@ export default {
         if('url' in component){
           // random is needed to avoid cache of components.
           var url = self.$kytos_server+component.url+"?random="+Math.random()
-          Vue.component(component.name, httpVueLoader(url))
+          //Vue.component(component.name, httpVueLoader(url))
         }
       })
     },

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -51,6 +51,12 @@ const options = {
    const style = Object.assign(document.createElement('style'), { textContent });
    const ref = document.head.getElementsByTagName('style')[0] || null;
    document.head.insertBefore(style, ref);
+ },
+
+ log(type, ...args) {
+
+   console.log("vue3-sfc-loader log:");
+   console[type](...args);
  }
 
 }

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -6,29 +6,54 @@
 
 <script>
 import Vue from 'vue'
-import httpVueLoader from "./httpVueLoader.js"
 import { loadModule } from "vue3-sfc-loader"
  
- const options = {
+const options = {
  
-   moduleCache: {
-     vue: Vue
-   },
- 
-   getFile(url) {
- 
-     return fetch(url).then(response => response.ok ? response.text() : Promise.reject(response));
-   },
- 
-   addStyle(styleStr) {
- 
-     const style = document.createElement('style');
-     style.textContent = styleStr;
-     const ref = document.head.getElementsByTagName('style')[0] || null;
-     document.head.insertBefore(style, ref);
-   }
- 
+ moduleCache: {
+   vue: Vue
+ },
+
+ pathResolve({ refPath, relPath }, options) {
+
+  if ( relPath === '.' )
+    return refPath;
+
+  if ( relPath[0] !== '.' && relPath[0] !== '/' )
+    return relPath;
+
+  return String(new URL(relPath, refPath === undefined ? window.location : refPath));
+ },
+
+ handleModule: async function (type, getContentData, path, options) {
+
+  switch (type) {
+    case '.css':
+      options.addStyle(await getContentData(false));
+      return null;
+    case '.kytos':
+      console.log("Kytos detected");
+      return null;
+    default: return undefined; // let vue3-sfc-loader handle this
+  }
+ },
+
+ async getFile(url) {
+
+   const res = await fetch(url);
+   if ( !res.ok )
+      throw Object.assign(new Error(url+' '+res.statusText), { res });
+   return await res.text();
+ },
+
+ addStyle(textContent) {
+
+   const style = Object.assign(document.createElement('style'), { textContent });
+   const ref = document.head.getElementsByTagName('style')[0] || null;
+   document.head.insertBefore(style, ref);
  }
+
+}
 
 export default {
   name: 'k-napps-info-panel',

--- a/src/components/kytos/napp/NappsInfoPanel.vue
+++ b/src/components/kytos/napp/NappsInfoPanel.vue
@@ -7,6 +7,28 @@
 <script>
 import Vue from 'vue'
 import httpVueLoader from "./httpVueLoader.js"
+import { loadModule } from "vue3-sfc-loader"
+ 
+ const options = {
+ 
+   moduleCache: {
+     vue: Vue
+   },
+ 
+   getFile(url) {
+ 
+     return fetch(url).then(response => response.ok ? response.text() : Promise.reject(response));
+   },
+ 
+   addStyle(styleStr) {
+ 
+     const style = document.createElement('style');
+     style.textContent = styleStr;
+     const ref = document.head.getElementsByTagName('style')[0] || null;
+     document.head.insertBefore(style, ref);
+   }
+ 
+ }
 
 export default {
   name: 'k-napps-info-panel',
@@ -25,11 +47,11 @@ export default {
         cache: false,
         success: function(data) {
           if(data) {
-            //self.components = self.components.concat(data)
+            self.components = self.components.concat(data)
           }
         }
       }).always(function(){
-          //self.load_components()
+          self.load_components()
       })
   },
   methods: {
@@ -38,8 +60,8 @@ export default {
       $.each(self.components, function(index, component){
         if('url' in component){
           // random is needed to avoid cache of components.
-          var url = self.$kytos_server+component.url+"?random="+Math.random()
-          //Vue.component(component.name, httpVueLoader(url))
+          var url = self.$kytos_server+component.url
+          self.$kytos.component(component.name, Vue.defineAsyncComponent( () => loadModule(url, options) ))
         }
       })
     },

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -55,6 +55,12 @@
      const style = Object.assign(document.createElement('style'), { textContent });
      const ref = document.head.getElementsByTagName('style')[0] || null;
      document.head.insertBefore(style, ref);
+   },
+
+   log(type, ...args) {
+     
+     console.log("vue3-sfc-loader log:");
+     console[type](...args);
    }
  
  }

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -10,7 +10,6 @@
  
  <script>
  import Vue from 'vue'
- import httpVueLoader from "./httpVueLoader.js"
  import { loadModule } from "vue3-sfc-loader"
  
  const options = {
@@ -18,16 +17,42 @@
    moduleCache: {
      vue: Vue
    },
+
+   pathResolve({ refPath, relPath }, options) {
+
+    if ( relPath === '.' )
+      return refPath;
+
+    if ( relPath[0] !== '.' && relPath[0] !== '/' )
+      return relPath;
+
+    return String(new URL(relPath, refPath === undefined ? window.location : refPath));
+   },
+
+   handleModule: async function (type, getContentData, path, options) {
+
+    switch (type) {
+      case '.css':
+        options.addStyle(await getContentData(false));
+        return null;
+      case '.kytos':
+        console.log("Kytos detected");
+        return null;
+      default: return undefined; // let vue3-sfc-loader handle this
+    }
+   },
+
+   async getFile(url) {
  
-   getFile(url) {
- 
-     return fetch(url).then(response => response.ok ? response.text() : Promise.reject(response));
+     const res = await fetch(url);
+     if ( !res.ok )
+        throw Object.assign(new Error(url+' '+res.statusText), { res });
+     return await res.text();
    },
  
-   addStyle(styleStr) {
+   addStyle(textContent) {
  
-     const style = document.createElement('style');
-     style.textContent = styleStr;
+     const style = Object.assign(document.createElement('style'), { textContent });
      const ref = document.head.getElementsByTagName('style')[0] || null;
      document.head.insertBefore(style, ref);
    }

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -47,7 +47,7 @@
      const res = await fetch(url);
      if ( !res.ok )
         throw Object.assign(new Error(url+' '+res.statusText), { res });
-     return await res.text();
+     return await {type: '.vue', getContentData: ()=>res.text()};
    },
  
    addStyle(textContent) {

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -1,93 +1,118 @@
 <template>
- <div class='k-toolbar' >
-  <component v-show="active == (index+1)"
-             v-for="(component, index) in inner_components"
-             :is="component.name"
-             v-bind:key="component.name">
-  </component>
- </div>
-</template>
-
-<script>
-import Vue from 'vue'
-import httpVueLoader from "./httpVueLoader.js"
-
-export default {
-  name: 'k-toolbar',
-  props: ["active", "compacted", "components"],
-  data () {
-    return {
-     url: this.$kytos_server+ 'ui/k-toolbar',
-     template: null,
-     inner_components: this.components || [] ,
-    }
-  },
-  render: function(createElement){
-    if (this.template) return this.template();
-  },
-  created() {
-      var self = this
-      $.get({
-        url: this.url,
-        datatype: 'json',
-        async: true,
-        cache: false,
-        success: function(data) {
-          self.inner_components = self.inner_components.concat(data);
-        }
-      }).always(function(){
-          self.load_components()
-          setTimeout(self.load_icons, 2000)
-      })
-  },
-  methods: {
-    load_icons () {
-      var self = this
-      var components  = $('.k-toolbar .k-toolbar-item')
-      $.each(components, function(index, component){
-          self.inner_components[index].icon = component.getAttribute('icon')
-          self.inner_components[index].tooltip = component.getAttribute('tooltip')
-      })
-      self.$emit('update:components', self.inner_components)
-    },
-    load_components (){
-      var self = this
-      $.each(self.inner_components, function(index, component){
-        if('url' in component){
-          // random is needed to avoid cache of components.
-          var url = self.$kytos_server+component.url+"?random="+Math.random()
-          Vue.component(component.name, httpVueLoader(url))
-        }
-      })
-    }
+  <div class='k-toolbar' >
+   <component v-show="active == (index+1)"
+              v-for="(component, index) in inner_components"
+              :is='component.name'
+              v-bind:key="component.name">
+   </component>
+  </div>
+ </template>
+ 
+ <script>
+ import Vue from 'vue'
+ import httpVueLoader from "./httpVueLoader.js"
+ import { loadModule } from "vue3-sfc-loader"
+ 
+ const options = {
+ 
+   moduleCache: {
+     vue: Vue
+   },
+ 
+   getFile(url) {
+ 
+     return fetch(url).then(response => response.ok ? response.text() : Promise.reject(response));
+   },
+ 
+   addStyle(styleStr) {
+ 
+     const style = document.createElement('style');
+     style.textContent = styleStr;
+     const ref = document.head.getElementsByTagName('style')[0] || null;
+     document.head.insertBefore(style, ref);
+   }
+ 
  }
-}
-</script>
-
-<style lang="sass">
-
-@import '../../../assets/styles/variables'
-
-.k-toolbar
-  -webkit-order: 2
-  -ms-flex-order: 2
-  z-index: 999
-  margin-top: 40px
-  padding: 5px 10px
-  background: $fill-panel
-  width: 220px
-  display: block
-
-.compacted
+ 
+ export default {
+   name: 'k-toolbar',
+   props: ["active", "compacted", "components"],
+   data () {
+     return {
+      url: this.$kytos_server+ 'ui/k-toolbar',
+      template: null,
+      inner_components: this.components || [] ,
+     }
+   },
+   render: function(createElement){
+     if (this.template) return this.template();
+   },
+   created() {
+       var self = this
+       $.get({
+         url: this.url,
+         datatype: 'json',
+         async: true,
+         cache: false,
+         success: function(data) {
+           console.log(data)
+           self.inner_components = self.inner_components.concat(data);
+           console.log(self.inner_components)
+         }
+       }).always(function(){
+           self.load_components()
+           setTimeout(self.load_icons, 2000)
+       })
+   },
+   methods: {
+     load_icons () {
+       var self = this
+       var components  = $('.k-toolbar .k-toolbar-item')
+       $.each(components, function(index, component){
+           self.inner_components[index].icon = component.getAttribute('icon')
+           self.inner_components[index].tooltip = component.getAttribute('tooltip')
+       })
+       self.$emit('update:components', self.inner_components)
+     },
+     load_components (){
+       var self = this
+       $.each(self.inner_components, function(index, component){
+         if('url' in component){
+           // random is needed to avoid cache of components.
+           var url = self.$kytos_server+component.url
+           self.$kytos.component(component.name, Vue.defineAsyncComponent( () => loadModule(url, options) ))
+         }
+       })
+     }
+  }
+ }
+ </script>
+ 
+ <style lang="sass">
+ 
+ @import '../../../assets/styles/variables'
+ 
  .k-toolbar
-  width: 100vw
-  height: 40px
-  margin-top: 0px
-  box-shadow: 5px 2px 10px $kytos-black
-  overflow: hidden
-  padding: 0px
-
-  .no-compact
-   display: none
-
-</style>
+   -webkit-order: 2
+   -ms-flex-order: 2
+   z-index: 999
+   margin-top: 40px
+   padding: 5px 10px
+   background: $fill-panel
+   width: 220px
+   display: block
+ 
+ .compacted
+  .k-toolbar
+   width: 100vw
+   height: 40px
+   margin-top: 0px
+   box-shadow: 5px 2px 10px $kytos-black
+   overflow: hidden
+   padding: 0px
+ 
+   .no-compact
+    display: none
+ 
+ </style>
+ 

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -36,7 +36,7 @@
         options.addStyle(await getContentData(false));
         return null;
       case '.kytos':
-        console.log("Kytos detected");
+        console.log("Kytos extension detected. Switch extension to .vue");
         return null;
       default: return undefined; // let vue3-sfc-loader handle this
     }
@@ -86,9 +86,7 @@
          async: true,
          cache: false,
          success: function(data) {
-           console.log(data)
            self.inner_components = self.inner_components.concat(data);
-           console.log(self.inner_components)
          }
        }).always(function(){
            self.load_components()

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -17,7 +17,7 @@ module.exports = {
         options: {
           compilerOptions: {
             compatConfig: {
-              MODE: 2,
+              MODE: 3,
             }
           },
           loaders: {


### PR DESCRIPTION
Closes #85
Closes #105 

### Summary

Replaced httpvueloader with vue3-sfc-loader.

Mef-eline was trying to access and change the value of a prop within `k-accordion-item` through references, and props are read only. Because of this, the prop was switched for a data element since no component was using the prop functionality and the data element can be modified.

Mef-eline was trying to give the prop named value from `k-input` an integer value. This prop was typed and expected a string; because of this, the type specification was removed from the prop, and now it can accept any value.

Enabled the ability to disable `k-input` for text display purposes only.

### Local Tests

To test the new additions all of the UI elements were used.

### Note

Replace `.kytos` file extension with `.vue`.
Incorporate changes from drafts in other napps for vue3-sfc-loader compatibility.
