### PR TITLE
StatusMenu Visibility Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
+- StatusMenu now clears Infopanels before use so that it displays properly.
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
-- StatusMenu now clears Infopanels before use so that it displays properly.
+- MenuBar now clears Infopanels before switching to a new item for better visibility.
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/src/components/kytos/misc/Menubar.vue
+++ b/src/components/kytos/misc/Menubar.vue
@@ -40,6 +40,7 @@ export default {
       this.$kytos.eventBus.$emit('topology-toggle-label', type, label)
     },
     setItem (item) {
+      this.$kytos.eventBus.$emit("hideInfoPanel")
       this.activeItem = item
       $(".k-toolbar").show();
 

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -633,6 +633,10 @@
         this.selectedInterfaces = JSON.parse(localStorage.getItem('kytos/ui/selectedInterfaces'));
       }
     },
+    //Closes Info Panels so that the Status Menu can be viewed.
+    beforeUpdate() {
+      this.$kytos.eventBus.$emit("hideInfoPanel")
+    },
     //Watches to see if data is changed to then store it within localStorage.
     watch: {
       switchTextFilter(newVal) {

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -633,10 +633,6 @@
         this.selectedInterfaces = JSON.parse(localStorage.getItem('kytos/ui/selectedInterfaces'));
       }
     },
-    //Closes Info Panels so that the Status Menu can be viewed.
-    beforeUpdate() {
-      this.$kytos.eventBus.$emit("hideInfoPanel")
-    },
     //Watches to see if data is changed to then store it within localStorage.
     watch: {
       switchTextFilter(newVal) {


### PR DESCRIPTION
Closes #110 

### Summary

`StatusMenu` wasn't visible when an `Infopanel` was displayed over it. Because of this, the `MenuBar` now closes `Infopanels` before switching to a new item.

### Local Tests

I listed the EVCs from `mef_eline` and then accessed the `StatusMenu`; the EVC list was then removed.
