### PR TITLE
Backport StatusMenu Visibility Fix to 2023.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
 - [backport] Added confirmation modal when enabling/disabling interfaces
+- [backport] StatusMenu now clears Infopanels before use so that it displays properly
 
 [2023.2.1] - 2024-06-04
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2023.2.3] - 2024-10-25
+***********************
+
+Changed
+=======
+- [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
+
 [2023.2.2] - 2024-10-07
 ***********************
 
@@ -13,7 +20,6 @@ Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
 - [backport] Added confirmation modal when enabling/disabling interfaces.
-- [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
 
 [2023.2.1] - 2024-06-04
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ UNRELEASED - Under development
 Changed
 =======
 - Fixed Enter key handler on InputAutocomplete (k-input-auto)
-- [backport] Added confirmation modal when enabling/disabling interfaces
-- [backport] StatusMenu now clears Infopanels before use so that it displays properly
+- [backport] Added confirmation modal when enabling/disabling interfaces.
+- [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
 
 [2023.2.1] - 2024-06-04
 ***********************

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2023.2.2",
+  "version": "2023.2.3",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/misc/Menubar.vue
+++ b/src/components/kytos/misc/Menubar.vue
@@ -40,6 +40,7 @@ export default {
       this.$kytos.$emit('topology-toggle-label', type, label)
     },
     setItem (item) {
+      this.$kytos.$emit("hideInfoPanel");
       this.activeItem = item
       $(".k-toolbar").show();
 

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -638,19 +638,33 @@ export default {
     switchTextFilter(newVal) {
       localStorage.setItem('kytos/ui/switchTextFilter',  JSON.stringify(newVal))
     },
-    deep: true
-  },
-  selectedLinks: {
-    handler: function() {
-      localStorage.setItem('kytos/ui/selectedLinks', JSON.stringify(this.selectedLinks))
+    linkTextFilter(newVal) {
+      localStorage.setItem('kytos/ui/linkTextFilter',  JSON.stringify(newVal))
     },
-    deep: true
-  },
-  selectedInterfaces: {
-    handler: function() {
-      localStorage.setItem('kytos/ui/selectedInterfaces', JSON.stringify(this.selectedInterfaces))
+    interfaceTextFilter(newVal) {
+      localStorage.setItem('kytos/ui/interfaceTextFilter',  JSON.stringify(newVal))
     },
-    deep: true
+    currentSwitchData(newVal) {
+      localStorage.setItem('kytos/ui/currentSwitchData', JSON.stringify(newVal))
+    },
+    currentLinkData(newVal) {
+      localStorage.setItem('kytos/ui/currentLinkData', JSON.stringify(newVal))
+    },
+    currentInterfaceData(newVal) {
+      localStorage.setItem('kytos/ui/currentInterfaceData', JSON.stringify(newVal))
+    },
+    selectedLinks: {
+      handler: function() {
+        localStorage.setItem('kytos/ui/selectedLinks', JSON.stringify(this.selectedLinks))
+      },
+      deep: true
+    },
+    selectedInterfaces: {
+      handler: function() {
+        localStorage.setItem('kytos/ui/selectedInterfaces', JSON.stringify(this.selectedInterfaces))
+      },
+      deep: true
+    },
   },
   filters: {
     splitStatusReasons: function(statusReasons) {

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -629,44 +629,28 @@ export default {
       this.selectedInterfaces = JSON.parse(localStorage.getItem('kytos/ui/selectedInterfaces'));
     }
   },
+  //Closes Info Panels so that the Status Menu can be viewed.
+  beforeUpdate() {
+    this.$kytos.eventBus.$emit("hideInfoPanel")
+  },
   //Watches to see if data is changed to then store it within localStorage.
   watch: {
     switchTextFilter(newVal) {
       localStorage.setItem('kytos/ui/switchTextFilter',  JSON.stringify(newVal))
     },
-    linkTextFilter(newVal) {
-      localStorage.setItem('kytos/ui/linkTextFilter',  JSON.stringify(newVal))
+    deep: true
+  },
+  selectedLinks: {
+    handler: function() {
+      localStorage.setItem('kytos/ui/selectedLinks', JSON.stringify(this.selectedLinks))
     },
-    interfaceTextFilter(newVal) {
-      localStorage.setItem('kytos/ui/interfaceTextFilter',  JSON.stringify(newVal))
+    deep: true
+  },
+  selectedInterfaces: {
+    handler: function() {
+      localStorage.setItem('kytos/ui/selectedInterfaces', JSON.stringify(this.selectedInterfaces))
     },
-    currentSwitchData(newVal) {
-      localStorage.setItem('kytos/ui/currentSwitchData', JSON.stringify(newVal))
-    },
-    currentLinkData(newVal) {
-      localStorage.setItem('kytos/ui/currentLinkData', JSON.stringify(newVal))
-    },
-    currentInterfaceData(newVal) {
-      localStorage.setItem('kytos/ui/currentInterfaceData', JSON.stringify(newVal))
-    },
-    selectedSwitches: {
-      handler: function() {
-        localStorage.setItem('kytos/ui/selectedSwitches', JSON.stringify(this.selectedSwitches))
-      },
-      deep: true
-    },
-    selectedLinks: {
-      handler: function() {
-        localStorage.setItem('kytos/ui/selectedLinks', JSON.stringify(this.selectedLinks))
-      },
-      deep: true
-    },
-    selectedInterfaces: {
-      handler: function() {
-        localStorage.setItem('kytos/ui/selectedInterfaces', JSON.stringify(this.selectedInterfaces))
-      },
-      deep: true
-    },
+    deep: true
   },
   filters: {
     splitStatusReasons: function(statusReasons) {
@@ -674,7 +658,6 @@ export default {
     }
   }
 }
-
 </script>
 
 <style lang="sass">

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -653,6 +653,12 @@ export default {
     currentInterfaceData(newVal) {
       localStorage.setItem('kytos/ui/currentInterfaceData', JSON.stringify(newVal))
     },
+    selectedSwitches: {
+      handler: function() {
+        localStorage.setItem('kytos/ui/selectedSwitches', JSON.stringify(this.selectedSwitches))
+      },
+      deep: true
+    },
     selectedLinks: {
       handler: function() {
         localStorage.setItem('kytos/ui/selectedLinks', JSON.stringify(this.selectedLinks))

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -629,10 +629,6 @@ export default {
       this.selectedInterfaces = JSON.parse(localStorage.getItem('kytos/ui/selectedInterfaces'));
     }
   },
-  //Closes Info Panels so that the Status Menu can be viewed.
-  beforeUpdate() {
-    this.$kytos.eventBus.$emit("hideInfoPanel")
-  },
   //Watches to see if data is changed to then store it within localStorage.
   watch: {
     switchTextFilter(newVal) {


### PR DESCRIPTION
Closes #112

### Summary

Backported StatusMenu visibility to `base/2023.2.3`. MenuBar now clears Infopanels before switching to a new item. This means that the StatusMenu will now be visible when accessed.

### Local Tests

The fix was tested in prod and infopanel was cleared before StatusMenu use.
