### PR TITLE
Backport StatusMenu Visibility Fix to 2024.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,32 +6,14 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
-[2024.1.1] - 2024-10-08
+[2023.2.2] - 2024-10-07
 ***********************
 
 Changed
 =======
- - Fixed Enter key handler on InputAutocomplete (k-input-auto)
- - [backport] Added confirmation modal when enabling/disabling interfaces
-
-[2024.1.0] - 2024-08-16
-***********************
-
-No major changes since the last 2024.1.0-b2 beta release.
-
-[2024.1.0-b2] - 2024-09-10
-***********************
-
-Fixed
-=======
-- Fixed buttons within ``interfaceInfo.vue`` that were using old ``on_click``.
-
-[2024.1.0-b1] - 2024-08-05
-***********************
-
-Changed
-=======
-- Upgraded Vue framework to Vue3 in compatibility mode.
+- Fixed Enter key handler on InputAutocomplete (k-input-auto)
+- [backport] Added confirmation modal when enabling/disabling interfaces.
+- [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
 
 [2023.2.1] - 2024-06-04
 ***********************
@@ -47,7 +29,6 @@ Changed
 
 Fixed
 =====
-- Fixed tooltip for inputs not displaying
 - Error handler properly showing the error message as text (Issue #60)
 
 [2023.2.0] - 2024-02-16

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,33 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
-[2023.2.2] - 2024-10-07
+[2024.1.1] - 2024-10-08
 ***********************
 
 Changed
 =======
-- Fixed Enter key handler on InputAutocomplete (k-input-auto)
-- [backport] Added confirmation modal when enabling/disabling interfaces.
-- [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
+ - Fixed Enter key handler on InputAutocomplete (k-input-auto)
+ - [backport] Added confirmation modal when enabling/disabling interfaces
+ - [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
+
+[2024.1.0] - 2024-08-16
+***********************
+
+No major changes since the last 2024.1.0-b2 beta release.
+
+[2024.1.0-b2] - 2024-09-10
+***********************
+
+Fixed
+=======
+- Fixed buttons within ``interfaceInfo.vue`` that were using old ``on_click``.
+
+[2024.1.0-b1] - 2024-08-05
+***********************
+
+Changed
+=======
+- Upgraded Vue framework to Vue3 in compatibility mode.
 
 [2023.2.1] - 2024-06-04
 ***********************
@@ -29,6 +48,7 @@ Changed
 
 Fixed
 =====
+- Fixed tooltip for inputs not displaying
 - Error handler properly showing the error message as text (Issue #60)
 
 [2023.2.0] - 2024-02-16

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,20 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2024.1.2] - 2024-10-25
+***********************
+
+Changed
+=======
+ - [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
+
 [2024.1.1] - 2024-10-08
 ***********************
 
 Changed
 =======
  - Fixed Enter key handler on InputAutocomplete (k-input-auto)
- - [backport] Added confirmation modal when enabling/disabling interfaces
- - [backport] MenuBar now clears Infopanels before switching to a new item for better visibility.
+ - [backport] Added confirmation modal when enabling/disabling interfaces.
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "scripts": {

--- a/src/components/kytos/misc/Menubar.vue
+++ b/src/components/kytos/misc/Menubar.vue
@@ -40,6 +40,7 @@ export default {
       this.$kytos.eventBus.$emit('topology-toggle-label', type, label)
     },
     setItem (item) {
+      this.$kytos.eventBus.$emit("hideInfoPanel")
       this.activeItem = item
       $(".k-toolbar").show();
 


### PR DESCRIPTION
Closes #113

### Summary

Backported StatusMenu visibility to `base/2024.1.2`. MenuBar now clears Infopanels before switching to a new item. This means that the StatusMenu will now be visible when accessed.

### Local Tests

The fix was tested in prod and infopanel was cleared before StatusMenu use.
