### PR TITLE
Added a prop called customClass

### DIFF
--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-checkbox-wrap">
+  <div :class="{[customClass]: true, 'k-checkbox-wrap': true}">
   <icon v-if="icon && iconName" :icon="iconName"></icon>
   <label class="checkbox">
     <input type="checkbox" id="checkbox" v-model="enabled" @change="update_check()">
@@ -48,6 +48,13 @@ export default {
       action: {
         type: Function,
         default: function(value) { return }
+      },
+      /**
+       * Custom CSS Classes
+       */
+      customClass: {
+        type: String,
+        default: ""
       }
   },
   methods: {

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -90,7 +90,6 @@ export default {
  font-size: 0.8em
  min-height: 30px
  color: $fill-text
- background: $fill-button-bg
 
  &:hover svg
   fill: $fill-icon-h

--- a/src/components/kytos/inputs/Dropdown.vue
+++ b/src/components/kytos/inputs/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-   <label class="k-dropdown" v-bind:class="{ 'no-title' : !title }">
+   <label class="k-dropdown" v-bind:class="{ [customClass]: true, 'no-title' : !title  }">
     <div class="k-dropdown__title">
       <icon v-if="icon && iconName" :icon="iconName"></icon>
       {{title}}
@@ -54,6 +54,13 @@ export default {
     action: {
       type: Function,
       default: function (value) { return }
+    },
+    /**
+     * Custom CSS Classes
+     */
+    customClass: {
+      type: String,
+      default: ""
     }
   },
   data () {

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-input-wrap">
+  <div :class="{[customClass]: true, 'k-input-wrap': true}">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
@@ -50,6 +50,13 @@ export default {
    action: {
       type: Function,
       default: function(val) {return}
+   },
+   /**
+   * Custom CSS Classes
+   */
+   customClass: {
+      type: String,
+      default: ""
    }
   },
   emits: ['update:value'],

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-input-auto-wrap" id="app">
+  <div :class="{[customClass]: true, 'k-input-auto-wrap': true}" id="app">
     <autocomplete
       :search="search"
       :placeholder="placeholder"
@@ -189,6 +189,13 @@ export default {
    },
    candidates: {
      type: Array
+   },
+   /**
+   * Custom CSS Classes
+   */
+   customClass: {
+     type: String,
+     default: ""
    }
   },
   methods: {

--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -1,5 +1,5 @@
 <template>
-   <label class="k-select no-compact">
+   <label :class="{[customClass]: true, 'k-select': true, 'no-compact': true}">
     <div class="k-select__title">
       <icon v-if="icon && iconName"  :icon="iconName"></icon>
       {{title}}
@@ -40,9 +40,16 @@ export default {
       type: Object,
       default: undefined
     },
-      action: {
+    action: {
       type: Function,
       default: function (value) { return }
+    },
+    /**
+    * Custom CSS Classes
+    */
+    customClass: {
+      type: String,
+      default: ""
     }
   },
   data () {

--- a/src/components/kytos/inputs/Slider.vue
+++ b/src/components/kytos/inputs/Slider.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-slider">
+  <div :class="{[customClass]: true, 'k-slider': true}">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <span class="range-slider__value">{{value}}</span>
     <input @input="doRange" :id="id" class="k-slider__range" type="range" :value="value" v-bind:min="min" v-bind:max="max" v-bind:step="step">
@@ -55,6 +55,13 @@ export default {
     step: {
       type: Number,
       default: 1
+    },
+    /**
+     * Custom CSS Classes
+     */
+    customClass: {
+      type: String,
+      default: ""
     }
   },
   data () {

--- a/src/components/kytos/inputs/Textarea.vue
+++ b/src/components/kytos/inputs/Textarea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-textarea-wrap no-compact">
+  <div :class="{[customClass]: true, 'k-textarea-wrap': true, 'no-compact': true}">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <textarea ref="textarea" @input="updateText" type="text" :id="id" class="k-textarea" :value="value" :tooltip="tooltip" :placeholder="placeholder"
       v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>
@@ -45,6 +45,13 @@ export default {
    action: {
       type: Function,
       default: function(value) {return}
+   },
+   /**
+    * Custom CSS Classes
+    */
+   customClass: {
+      type: String,
+      default: ""
    }
   },
   methods: {

--- a/src/components/kytos/inputs/buttons/Button.vue
+++ b/src/components/kytos/inputs/buttons/Button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :id="id" class="k-button compact"
+  <button :id="id" :class="{[customClass]: true, 'k-button': true, 'compact': true}"
     @click="handleClick"
     v-bind:title="tooltip"
     v-bind:disabled="isDisabled">
@@ -24,6 +24,15 @@ export default {
   name: 'k-button',
   mixins: [KytosBaseWithIcon],
   emits: ['click'],
+  props: {
+    /**
+     * Custom CSS Classes
+     */
+    customClass: {
+      type: String,
+      default: ""
+    }
+  },
   methods: {
      /**
      * Call click event.


### PR DESCRIPTION
Closes #116 
Closes #117 

### Summary

Added a prop called `customClass` that users can utilize to give classes to their `k-components`. 
This is needed since classes by default do not function with the vue3-sfc-loader.

This change will also require going through each individual NAPP component and forcing them to use the new `customClass` prop. The components being used within the main UI repo can remain unchanged.

### Local Tests

The code was ran and the CSS functioned once more.
