### PR TITLE
this.$set() was removed since it was deprecated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 - Replaced listeners with attrs
 - Replaced value with modelValue
 - Replaced the use of Vue and new Vue with the app instace
+- Removed the use of this.$set() since it was deprecated
 
 Fixed
 =======

--- a/src/components/kytos/misc/StatusMenu.vue
+++ b/src/components/kytos/misc/StatusMenu.vue
@@ -381,7 +381,7 @@
         if (this.selectedSwitches[index]?.dpid == item.dpid) {
           delete this.selectedSwitches[index]
         } else {
-          this.$set(this.selectedSwitches, index, item);
+          this.selectedSwitches[index] = item;
         }
         this.change = this.change * -1
         this.$forceUpdate();
@@ -390,7 +390,7 @@
         if (this.selectedLinks[index]?.id == item.id) {
           delete this.selectedLinks[index]
         } else {
-          this.$set(this.selectedLinks, index, item);
+          this.selectedLinks[index] = item;
         }
         this.change = this.change * -1
         this.$forceUpdate();
@@ -399,7 +399,7 @@
         if (this.selectedInterfaces[index]?.id == item.id) {
           delete this.selectedInterfaces[index]
         } else {
-          this.$set(this.selectedInterfaces, index, item);
+          this.selectedInterfaces[index] = item;
         }
         this.change = this.change * -1
         this.$forceUpdate();

--- a/src/components/kytos/table/Table.vue
+++ b/src/components/kytos/table/Table.vue
@@ -134,7 +134,7 @@ export default {
       if(newSort === this.currentSort) {
         let sortDir = (this.currentSortDir[newSort] === 'asc') ? 'desc' : 'asc'
 
-        this.$set(this.currentSortDir, newSort, sortDir)
+        this.currentSortDir[newSort] = sortDir;
         /**
         * It is necessary to use a different syntax to replace arrays values
         * by index because Vue cannot detect when directly set an item with

--- a/src/components/kytos/table/Table.vue
+++ b/src/components/kytos/table/Table.vue
@@ -135,12 +135,6 @@ export default {
         let sortDir = (this.currentSortDir[newSort] === 'asc') ? 'desc' : 'asc'
 
         this.currentSortDir[newSort] = sortDir;
-        /**
-        * It is necessary to use a different syntax to replace arrays values
-        * by index because Vue cannot detect when directly set an item with
-        * the index like it is usually done. In this case should've been:
-        * this.currentSortDir[newSort] = sortDir
-        */
       }
       this.currentSort = newSort;
     },


### PR DESCRIPTION
Closes #122

### Summary

this.$set() was used in vue js 2 to add reactive properties to objects. Within vue js 3 this is no longer needed since properties are made reactive by default, so it was removed.

### Local Tests

After removing the use of set I no longer got a warning for the using it.

### End-to-End Tests
