### PR TITLE
Removed class prop that was overloading class attribute and also removed customClass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 - Replaced value with modelValue
 - Replaced the use of Vue and new Vue with the app instace
 - Removed the use of this.$set() since it was deprecated
+- Removed customClass
 
 Fixed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 Fixed
 =======
 - Fixed icon v-bind within StatusMenu
+- Fixed CSS issue with ``KytosBaseWithIcon`` class prop
 
 [2024.1.0] - 2024-08-16
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,6 @@ Added
 =====
 - Added new "k-modal" component.
 - Added confirmation modal when enabling/disabling interfaces
-- Added a prop called customClass, so that NApps can implement classes with the new vue3-sfc-loader
 
 Changed
 =======
@@ -20,7 +19,6 @@ Changed
 - Replaced value with modelValue
 - Replaced the use of Vue and new Vue with the app instace
 - Removed the use of this.$set() since it was deprecated
-- Removed customClass
 
 Fixed
 =======

--- a/src/components/kytos/base/KytosBaseWithIcon.js
+++ b/src/components/kytos/base/KytosBaseWithIcon.js
@@ -25,9 +25,6 @@ export default {
      */
     icon: {
       type: String,
-    },
-    class: {
-      type: String,
     }
   },
   components: {

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -48,13 +48,6 @@ export default {
       action: {
         type: Function,
         default: function(value) { return }
-      },
-      /**
-       * Custom CSS Classes
-       */
-      customClass: {
-        type: String,
-        default: ""
       }
   },
   methods: {

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{[customClass]: true, 'k-checkbox-wrap': true}">
+  <div class="k-checkbox-wrap">
   <icon v-if="icon && iconName" :icon="iconName"></icon>
   <label class="checkbox">
     <input type="checkbox" id="checkbox" v-model="enabled" @change="update_check()">

--- a/src/components/kytos/inputs/Dropdown.vue
+++ b/src/components/kytos/inputs/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-   <label class="k-dropdown" v-bind:class="{ [customClass]: true, 'no-title' : !title  }">
+   <label class="k-dropdown" v-bind:class="{'no-title' : !title  }">
     <div class="k-dropdown__title">
       <icon v-if="icon && iconName" :icon="iconName"></icon>
       {{title}}

--- a/src/components/kytos/inputs/Dropdown.vue
+++ b/src/components/kytos/inputs/Dropdown.vue
@@ -16,95 +16,88 @@ import KytosBase from '../base/KytosBase';
 import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 
 /**
- * A toggleable menu that allows the user to choose one value from a predefined list.
- *
- * @example k-dropdown title="Switch Labels:" icon="circle" :options="switchLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'switch'}}"></k-dropdown>
- * @example /_static/imgs/components/input/k-dropdown.png
- */
+* A toggleable menu that allows the user to choose one value from a predefined list.
+*
+* @example k-dropdown title="Switch Labels:" icon="circle" :options="switchLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'switch'}}"></k-dropdown>
+* @example /_static/imgs/components/input/k-dropdown.png
+*/
 
 export default {
-  name: 'k-dropdown',
-  mixins: [KytosBaseWithIcon],
-  props: {
-    /**
-     * Property with the selected option.
-     */
-    value:{
-      type: [String, Boolean],
-      default: ""
-    },
-    /**
-     * A collection with all options that could be selected.
-     */
-    options: {
-      type: Array,
-      required: true
-    },
-    /**
-     * An event triggered when the dropdown change, this event should have the
-     * following content: {**name**: 'event_name', **content**: {} }
-     */
-    event: {
-      type: Object,
-      default: undefined
-    },
-    /**
-     * Optinal action called after select a dropdown option.
-     */
-    action: {
-      type: Function,
-      default: function (value) { return }
-    },
-    /**
-     * Custom CSS Classes
-     */
-    customClass: {
-      type: String,
-      default: ""
-    }
-  },
-  data () {
-    return {
-      selected: ''
-    }
-  },
-  methods: {
-    emitEvent () {
-      if (this.event !== undefined){
-        let content = this.event.content
-        content.value = this.selected
-        this.$kytos.eventBus.$emit(this.event.name, content)
-      }
-      this.$emit('update:value', this.selected)
-      this.action(this.selected)
-    },
-    clear () {
-      this.selected = '';
-    },
-    reset () {
-      this.selected = '';
-      if(this.options && this.options.length > 0) {
-        this.options.forEach((item) => {
-          if (this.selected == '' && item.selected) {this.selected = item.value}
-        })
-      }
-    }
-  },
-  mounted () {
-    this.options.forEach((item) => {
-      if (this.selected == '' && item.selected) {this.selected = item.value}
-    })
-  },
-  watch: {
-    selected () {
-      this.emitEvent()
-    },
-    options () {
-      this.options.forEach((item) => {
-        if (this.selected == '' && item.selected) {this.selected = item.value }
-      })
-    }
-  }
+ name: 'k-dropdown',
+ mixins: [KytosBaseWithIcon],
+ props: {
+   /**
+    * Property with the selected option.
+    */
+   value:{
+     type: [String, Boolean],
+     default: ""
+   },
+   /**
+    * A collection with all options that could be selected.
+    */
+   options: {
+     type: Array,
+     required: true
+   },
+   /**
+    * An event triggered when the dropdown change, this event should have the
+    * following content: {**name**: 'event_name', **content**: {} }
+    */
+   event: {
+     type: Object,
+     default: undefined
+   },
+   /**
+    * Optinal action called after select a dropdown option.
+    */
+   action: {
+     type: Function,
+     default: function (value) { return }
+   }
+ },
+ data () {
+   return {
+     selected: ''
+   }
+ },
+ methods: {
+   emitEvent () {
+     if (this.event !== undefined){
+       let content = this.event.content
+       content.value = this.selected
+       this.$kytos.eventBus.$emit(this.event.name, content)
+     }
+     this.$emit('update:value', this.selected)
+     this.action(this.selected)
+   },
+   clear () {
+     this.selected = '';
+   },
+   reset () {
+     this.selected = '';
+     if(this.options && this.options.length > 0) {
+       this.options.forEach((item) => {
+         if (this.selected == '' && item.selected) {this.selected = item.value}
+       })
+     }
+   }
+ },
+ mounted () {
+   this.options.forEach((item) => {
+     if (this.selected == '' && item.selected) {this.selected = item.value}
+   })
+ },
+ watch: {
+   selected () {
+     this.emitEvent()
+   },
+   options () {
+     this.options.forEach((item) => {
+       if (this.selected == '' && item.selected) {this.selected = item.value }
+     })
+   }
+ }
 }
 </script>
 

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -50,13 +50,6 @@ export default {
    action: {
       type: Function,
       default: function(val) {return}
-   },
-   /**
-   * Custom CSS Classes
-   */
-   customClass: {
-      type: String,
-      default: ""
    }
   },
   emits: ['update:value'],

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{[customClass]: true, 'k-input-wrap': true}">
+  <div class="k-input-wrap">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <input :value="value" :id="id" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{[customClass]: true, 'k-input-auto-wrap': true}" id="app">
+  <div class="k-input-auto-wrap" id="app">
     <autocomplete
       :search="search"
       :placeholder="placeholder"

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -189,13 +189,6 @@ export default {
    },
    candidates: {
      type: Array
-   },
-   /**
-   * Custom CSS Classes
-   */
-   customClass: {
-     type: String,
-     default: ""
    }
   },
   methods: {

--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -43,13 +43,6 @@ export default {
     action: {
       type: Function,
       default: function (value) { return }
-    },
-    /**
-    * Custom CSS Classes
-    */
-    customClass: {
-      type: String,
-      default: ""
     }
   },
   data () {

--- a/src/components/kytos/inputs/Select.vue
+++ b/src/components/kytos/inputs/Select.vue
@@ -1,5 +1,5 @@
 <template>
-   <label :class="{[customClass]: true, 'k-select': true, 'no-compact': true}">
+   <label class="k-select no-compact">
     <div class="k-select__title">
       <icon v-if="icon && iconName"  :icon="iconName"></icon>
       {{title}}

--- a/src/components/kytos/inputs/Slider.vue
+++ b/src/components/kytos/inputs/Slider.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{[customClass]: true, 'k-slider': true}">
+  <div class="k-slider">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <span class="range-slider__value">{{value}}</span>
     <input @input="doRange" :id="id" class="k-slider__range" type="range" :value="value" v-bind:min="min" v-bind:max="max" v-bind:step="step">

--- a/src/components/kytos/inputs/Slider.vue
+++ b/src/components/kytos/inputs/Slider.vue
@@ -55,13 +55,6 @@ export default {
     step: {
       type: Number,
       default: 1
-    },
-    /**
-     * Custom CSS Classes
-     */
-    customClass: {
-      type: String,
-      default: ""
     }
   },
   data () {

--- a/src/components/kytos/inputs/Textarea.vue
+++ b/src/components/kytos/inputs/Textarea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{[customClass]: true, 'k-textarea-wrap': true, 'no-compact': true}">
+  <div class="k-textarea-wrap no-compact">
     <icon v-if="icon && iconName" :icon="iconName"></icon>
     <textarea ref="textarea" @input="updateText" type="text" :id="id" class="k-textarea" :value="value" :tooltip="tooltip" :placeholder="placeholder"
       v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>

--- a/src/components/kytos/inputs/Textarea.vue
+++ b/src/components/kytos/inputs/Textarea.vue
@@ -45,13 +45,6 @@ export default {
    action: {
       type: Function,
       default: function(value) {return}
-   },
-   /**
-    * Custom CSS Classes
-    */
-   customClass: {
-      type: String,
-      default: ""
    }
   },
   methods: {

--- a/src/components/kytos/inputs/buttons/Button.vue
+++ b/src/components/kytos/inputs/buttons/Button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :id="id" :class="{[customClass]: true, 'k-button': true, 'compact': true}"
+  <button :id="id" class="k-button compact"
     @click="handleClick"
     v-bind:title="tooltip"
     v-bind:disabled="isDisabled">

--- a/src/components/kytos/inputs/buttons/Button.vue
+++ b/src/components/kytos/inputs/buttons/Button.vue
@@ -24,15 +24,6 @@ export default {
   name: 'k-button',
   mixins: [KytosBaseWithIcon],
   emits: ['click'],
-  props: {
-    /**
-     * Custom CSS Classes
-     */
-    customClass: {
-      type: String,
-      default: ""
-    }
-  },
   methods: {
      /**
      * Call click event.


### PR DESCRIPTION
Closes #126 

### Summary

The KytosBaseWithIcon had a prop named class that was overloading almost all class attributes since it was getting mixed in with almost all base Kytos components.

Read the issue for a detailed explanation.

In addition to this, customClass was also removed since CSS was fixed.

### Local Tests

The CSS displayed properly without custom classes.

### End-to-End Tests
