### PR TITLE
Added Unit Tests utilizing the Vitest Framework

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Added new "k-modal" component.
 - Added confirmation modal when enabling/disabling interfaces
+- Added unit tests utilizing ``Vitest``
 
 Removed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 =====
 - Added new "k-modal" component.
 - Added confirmation modal when enabling/disabling interfaces
-- Added unit tests utilizing ``Vitest``
+- Added unit testing functionality utilizing ``Vitest``
 
 Removed
 =======

--- a/__test__/App.test.js
+++ b/__test__/App.test.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils';
+import App from '../src/App.vue';
+import { describe, expect, test } from "vitest";
+
+describe("App.vue", () => {
+    const wrapper = mount(App);
+    test("Does a wrapper exists?", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
+});

--- a/__test__/App.test.js
+++ b/__test__/App.test.js
@@ -1,9 +1,12 @@
 import { mount } from '@vue/test-utils';
-import App from '../src/App.vue';
-import { describe, expect, test } from "vitest";
+import App from '@/App.vue';
+import { describe, test, expect, beforeAll } from "vitest";
 
-describe("App.vue", () => {
+describe("App", () => {
     const wrapper = mount(App);
+    beforeAll(() => {
+        expect(App).toBeTruthy();
+    });
     test("Does a wrapper exists?", () => {
         expect(wrapper.exists()).toBe(true);
     });

--- a/__test__/App.test.js
+++ b/__test__/App.test.js
@@ -1,13 +1,20 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import App from '@/App.vue';
+import Menubar from '@/components/kytos/misc/Menubar.vue'
 import { describe, test, expect, beforeAll } from "vitest";
 
 describe("App", () => {
-    const wrapper = mount(App);
     beforeAll(() => {
         expect(App).toBeTruthy();
     });
     test("Does a wrapper exists?", () => {
+        const wrapper = mount(App, {
+            global: {
+              components: {
+                'k-menubar': Menubar
+              }
+            }
+    });
         expect(wrapper.exists()).toBe(true);
     });
 });

--- a/__test__/App.test.js
+++ b/__test__/App.test.js
@@ -1,6 +1,6 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import App from '@/App.vue';
-import Menubar from '@/components/kytos/misc/Menubar.vue'
+import Menubar from '@/components/kytos/misc/Menubar.vue';
 import { describe, test, expect, beforeAll } from "vitest";
 
 describe("App", () => {

--- a/__test__/components/kytos/inputs/Input.test.js
+++ b/__test__/components/kytos/inputs/Input.test.js
@@ -1,0 +1,151 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import Input from '@/components/kytos/inputs/Input.vue';
+import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
+
+//Inputs
+
+describe("Props", () => {
+    beforeAll(() => {
+        expect(Input).toBeTruthy();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("Disabling Input", async () => {
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+        expect(mainInput.element.hasAttribute('disabled')).toBe(false);
+
+        await wrapper.setProps({ isDisabled: true });
+
+        expect(mainInput.element.hasAttribute('disabled')).toBe(true);
+    });
+
+    test("Default Input Value", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        expect(mainInput.element.hasAttribute('value')).toBe(true);
+
+        await wrapper.setProps({ value: testValue });
+
+        expect(mainInput.attributes('value')).toBe(testValue);
+    });
+
+    test("Input Tooltip", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        expect(mainInput.element.hasAttribute('title')).toBe(false);
+
+        await wrapper.setProps({ tooltip: testValue });
+
+        expect(mainInput.attributes('title')).toBe(testValue);
+    });
+
+    test("Input Placeholder", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        expect(mainInput.element.hasAttribute('placeholder')).toBe(false);
+
+        await wrapper.setProps({ placeholder: testValue });
+
+        expect(mainInput.attributes('placeholder')).toBe(testValue);
+    });
+
+    test("Input Action", async () => {
+        const fn = vi.fn();
+        const text = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        expect(wrapper.props().hasOwnProperty('action')).toBe(true);
+
+        await wrapper.setProps({ action: fn });
+
+        expect(wrapper.props('action')).toBe(fn);
+
+        await mainInput.setValue(text);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith(text);
+    });
+
+});
+
+describe("User Interactions", () => {
+    beforeAll(() => {
+        expect(Input).toBeTruthy();
+    });
+
+    test("Input Data/Write/Use Input", async () => {
+        const text = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        await mainInput.setValue(text);
+
+        expect(mainInput.element.value).toContain(text);
+    });
+});
+
+//Outputs
+
+describe("DOM Elements", () => {
+    beforeAll(() => {
+        expect(Input).toBeTruthy();
+    });
+
+    test("Input", () => {
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+
+        expect(wrapper.find('[data-test="main-input"]').exists()).toBe(true);
+    });
+
+    test("Icon", async () => {
+        const testIcon = "arrow-right";
+        const wrapper = shallowMount(Input);
+        expect(wrapper.exists()).toBe(true);
+
+        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
+
+        await wrapper.setProps({ icon: testIcon });
+
+        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
+
+        const icon = wrapper.get('[data-test="main-icon"]');
+
+        expect(icon.attributes('icon')).toBe(testIcon);
+    });
+});
+
+describe("Emits", () => {
+    beforeAll(() => {
+        expect(Input).toBeTruthy();
+    });
+
+    test("Emit Input Value", async () => {
+        const text = 'test';
+        const wrapper = mount(Input);
+        expect(wrapper.exists()).toBe(true);
+        const mainInput = wrapper.get('[data-test="main-input"]');
+
+        await mainInput.setValue(text);
+
+        expect(wrapper.emitted('update:value')).toHaveLength(1);
+        expect(wrapper.emitted('update:value')[0]).toEqual([text]);
+    });
+});

--- a/__test__/components/kytos/inputs/Input.test.js
+++ b/__test__/components/kytos/inputs/Input.test.js
@@ -149,3 +149,24 @@ describe("Emits", () => {
         expect(wrapper.emitted('update:value')[0]).toEqual([text]);
     });
 });
+
+//V-Model
+
+describe("V-Models", () => {
+    beforeAll(() => {
+        expect(Input).toBeTruthy();
+    });
+
+    test("V-Model Value", async () => {
+        const text = 'test';
+        const wrapper = mount(Input, {
+            props: {
+              value: 'initialText',
+              'onUpdate:value': (e) => wrapper.setProps({ value: e })
+            }
+          })
+        
+          await wrapper.get('[data-test="main-input"]').setValue(text)
+          expect(wrapper.props('value')).toBe(text)
+        });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "vite build --emptyOutDir",
     "preprod": "vite build --emptyOutDir --mode preprod",
     "zip": "vite build --emptyOutDir > /dev/null && zip -r latest.zip web-ui/index.html web-ui/dist",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.2",
@@ -34,12 +36,16 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
+    "@vitest/coverage-v8": "^3.0.7",
     "@vue/compiler-sfc": "^3.1.0",
+    "@vue/test-utils": "^2.4.6",
     "cross-env": "^7.0.3",
+    "happy-dom": "^17.1.9",
     "jquery": "^3.6.0",
     "jquery-slider": "^0.0.1",
     "sass": "^1.85.1",
     "vite": "^6.0.7",
+    "vitest": "^3.0.7",
     "vue3-sfc-loader": "^0.9.5",
     "yargs": "^17.3.1"
   },

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="k-input-wrap">
-    <icon v-if="icon && iconName" :icon="iconName"></icon>
+    <icon v-if="icon && iconName" :icon="iconName" data-test="main-icon"></icon>
     <input :value="value" class="k-input" :title="tooltip" :placeholder="placeholder"
       @input="updateText"
       ref="inputValue"
-      v-bind:disabled="isDisabled" onshow="this.focus()" autofocus>
+      v-bind:disabled="isDisabled" onshow="this.focus()" autofocus 
+      data-test="main-input" />
   </div>
 </template>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,11 @@ export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
         sourcemap: true,
         minify: false
       },
+      resolve: {
+        alias: {
+          '@': resolve(__dirname, './src')
+        },
+      },
       test: {
         environment: "happy-dom",
         coverage: {
@@ -29,6 +34,11 @@ export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
         outDir: './web-ui/',
         assetsDir: './dist/',
         minify: true
+      },
+      resolve: {
+        alias: {
+          '@': resolve(__dirname, './src')
+        }
       },
       test: {
         environment: "happy-dom",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import { configDefaults } from 'vitest/config';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 
@@ -21,6 +22,9 @@ export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
         environment: "happy-dom",
         coverage: {
           reporter: ['text', 'html'],
+          exclude:[
+            ...configDefaults.exclude
+          ]
         }
       },
       css: {
@@ -44,6 +48,9 @@ export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
         environment: "happy-dom",
         coverage: {
           reporter: ['text', 'html'],
+          exclude:[
+            ...configDefaults.exclude
+          ]
         }
       }
     }


### PR DESCRIPTION
Closes #135

### Summary

Added unit testing capabilities utilizing the Vitest framework.
Added unit tests for `k-input`.

There are 3 main popular ways to store `Vitest` unit tests. I decided to use the one seen in this repository https://github.com/hsiangfeng/example-vue3-vitest/tree/main/ due to personal preference, since I thought it looked better.

This method involves creating a folder called `__test__` at the root of the project. This `__test__` folder mirrors the `src` directory. This means that it will follow the exact same structure as the `src` directory. The only difference is that the test files are kept where the source code files usually are. That is why the test folder mirrors the src folder, because it's the exact same as the src folder, only the files containing the source code are replaced with the tests. This makes it easy to find and identify the tests since they are in the exact same spot that their original source file would be located in.

The `unit tests` require an `environment` to run in; for this purpose, I decided to use `happy-dom`, but there is another alternative called `jsdom`. Both can be used to run unit tests in different environments at the same time; it just needs to be set up within the config.

You can `run the unit tests` using `npm run test` and you can get a coverage report using `npm run coverage`.

### Local Tests

The unit tests run.

### End-to-End Tests
