### PR TITLE
Added K-Checkbox Unit Tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ UNRELEASED - Under development
 
 Added
 =====
+- Explicitly added emits and validated them.
 - Added new "k-modal" component.
 - Added confirmation modal when enabling/disabling interfaces
 - Added unit testing functionality utilizing ``Vitest``

--- a/__test__/components/kytos/inputs/Checkbox.test.js
+++ b/__test__/components/kytos/inputs/Checkbox.test.js
@@ -1,0 +1,203 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import Checkbox from '@/components/kytos/inputs/Checkbox.vue';
+import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
+
+//Inputs
+
+describe.sequential("Props", () => {
+    beforeAll(() => {
+        expect(Checkbox).toBeTruthy();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("Checkbox Value", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(wrapper.props('value')).toBe(0);
+
+        await wrapper.setProps({ value: testValue });
+        await mainCheckbox.setChecked(true);
+
+        expect(wrapper.vm.list_of_checked).toEqual([testValue]);
+
+        await mainCheckbox.setChecked(false);
+
+        expect(wrapper.vm.list_of_checked).toEqual([]);
+    });
+
+    test("Checked as Default", () => {
+        const wrapper = mount(Checkbox, {
+            props: {
+                checked: true
+            }
+        });
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(mainCheckbox.element.checked).toBe(true);
+        expect(wrapper.vm.enabled).toBe(true);
+    });
+
+    test("UnChecked as Default", () => {
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(mainCheckbox.element.checked).toBe(false);
+        expect(wrapper.vm.enabled).toBe(false);
+    });
+
+    test("Checkbox Model", async () => {
+        const testArray = ['test1', 'test2'];
+        const wrapper = mount(Checkbox, {
+            props: {
+                model: [...testArray]
+            }
+        });
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(wrapper.vm.list_of_checked).toEqual(testArray);
+
+        await mainCheckbox.setChecked(true);
+
+        expect(wrapper.vm.list_of_checked).toEqual([...testArray, 0]);
+    });
+
+    test("Checkbox Action", async () => {
+        const fn = vi.fn();
+        const text = 'test';
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(wrapper.props().hasOwnProperty('action')).toBe(true);
+
+        await wrapper.setProps({
+            value: text,
+            action: fn
+         });
+
+        expect(wrapper.props('action')).toBe(fn);
+
+        await mainCheckbox.setChecked(true);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith(text);
+
+        //Hack to avoid state from crossing over to other unit tests
+        //Just undo the changes made and everything works fine
+        //Unchecking luckily also resets data
+        await mainCheckbox.setChecked(false);
+    });
+});
+
+describe("User Interactions", () => {
+    beforeAll(() => {
+        expect(Checkbox).toBeTruthy();
+    });
+
+    test("Click Checkbox", async () => {
+        const testValue = 'test';
+        const testModel = ['test1', 'test2'];
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        expect(mainCheckbox.element.checked).toBe(false);
+        expect(wrapper.vm.list_of_checked).toEqual([]);
+        expect(wrapper.vm.enabled).toBe(false);
+
+        await wrapper.setProps({ 
+            value: testValue,
+            model: [...testModel]
+         });
+        await mainCheckbox.setChecked(true);
+
+        expect(mainCheckbox.element.checked).toBe(true);
+        expect(wrapper.vm.list_of_checked).toEqual([...testModel, testValue]);
+        expect(wrapper.vm.enabled).toBe(true);
+
+        await mainCheckbox.setChecked(false);
+
+        expect(mainCheckbox.element.checked).toBe(false);
+        expect(wrapper.vm.list_of_checked).toEqual([...testModel]);
+        expect(wrapper.vm.enabled).toBe(false);
+    });
+});
+
+//Outputs
+
+describe("DOM Elements", () => {
+    beforeAll(() => {
+        expect(Checkbox).toBeTruthy();
+    });
+
+    test("Checkbox", () => {
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+
+        expect(wrapper.find('[data-test="main-checkbox"]').exists()).toBe(true);
+    });
+
+    test("Icon", async () => {
+        const testIcon = "arrow-right";
+        const wrapper = shallowMount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+
+        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
+
+        await wrapper.setProps({ icon: testIcon });
+
+        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
+
+        const icon = wrapper.get('[data-test="main-icon"]');
+
+        expect(icon.attributes('icon')).toBe(testIcon);
+    });
+});
+
+describe("Emits", () => {
+    beforeAll(() => {
+        expect(Checkbox).toBeTruthy();
+    });
+
+    test("Emit Checkbox Model", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Checkbox);
+        expect(wrapper.exists()).toBe(true);
+        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+        await wrapper.setProps({ value: testValue });
+        await mainCheckbox.setChecked(true);
+
+        expect(wrapper.emitted('update:model')).toHaveLength(1);
+        expect(wrapper.emitted('update:model')[0]).toEqual([[testValue]]);
+    });
+});
+
+describe("V-Models", () => {
+    beforeAll(() => {
+        expect(Checkbox).toBeTruthy();
+    });
+
+    test("V-Model Model", async () => {
+        const testValue = 'test';
+        const wrapper = mount(Checkbox, {
+            props: {
+              model: [],
+              'onUpdate:model': (e) => wrapper.setProps({ model: e }),
+              value: testValue
+            }
+        });
+        
+        await wrapper.get('[data-test="main-checkbox"]').setChecked(true);
+        expect(wrapper.props('model')).toEqual([testValue]);
+    });
+});

--- a/__test__/components/kytos/inputs/Checkbox.test.js
+++ b/__test__/components/kytos/inputs/Checkbox.test.js
@@ -2,202 +2,192 @@ import { mount, shallowMount } from '@vue/test-utils';
 import Checkbox from '@/components/kytos/inputs/Checkbox.vue';
 import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
-//Inputs
 
-describe("Props", () => {
+describe("Checkbox.vue", () => {
+    let wrapper;
     beforeAll(() => {
         expect(Checkbox).toBeTruthy();
     });
 
     afterEach(() => {
+        wrapper.unmount();
+        wrapper = null;
         vi.restoreAllMocks();
     });
 
-    test("Checkbox Value", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+    //Inputs
 
-        expect(wrapper.props('value')).toBe(0);
+    describe("Props", () => {
+        test("Checkbox Value", async () => {
+            const testValue = 'test';
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
 
-        await wrapper.setProps({ value: testValue });
-        await mainCheckbox.setChecked(true);
+            expect(wrapper.props('value')).toBe(0);
 
-        expect(wrapper.vm.list_of_checked).toEqual([testValue]);
+            await wrapper.setProps({ value: testValue });
+            await mainCheckbox.setChecked(true);
 
-        await mainCheckbox.setChecked(false);
+            expect(wrapper.vm.list_of_checked).toEqual([testValue]);
 
-        expect(wrapper.vm.list_of_checked).toEqual([]);
-    });
+            await mainCheckbox.setChecked(false);
 
-    test("Checked as Default", () => {
-        const wrapper = mount(Checkbox, {
-            props: {
-                checked: true
-            }
+            expect(wrapper.vm.list_of_checked).toEqual([]);
         });
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
 
-        expect(mainCheckbox.element.checked).toBe(true);
-        expect(wrapper.vm.enabled).toBe(true);
-    });
+        test("Checked as Default", () => {
+            wrapper = mount(Checkbox, {
+                props: {
+                    checked: true
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
 
-    test("UnChecked as Default", () => {
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
-
-        expect(mainCheckbox.element.checked).toBe(false);
-        expect(wrapper.vm.enabled).toBe(false);
-    });
-
-    test("Checkbox Model", async () => {
-        const testArray = ['test1', 'test2'];
-        const wrapper = mount(Checkbox, {
-            props: {
-                model: [...testArray]
-            }
+            expect(mainCheckbox.element.checked).toBe(true);
+            expect(wrapper.vm.enabled).toBe(true);
         });
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
 
-        expect(wrapper.vm.list_of_checked).toEqual(testArray);
+        test("UnChecked as Default", () => {
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
 
-        await mainCheckbox.setChecked(true);
-
-        expect(wrapper.vm.list_of_checked).toEqual([...testArray, 0]);
-    });
-
-    test("Checkbox Action", async () => {
-        const fn = vi.fn();
-        const text = 'test';
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
-
-        expect(wrapper.props().hasOwnProperty('action')).toBe(true);
-
-        await wrapper.setProps({
-            value: text,
-            action: fn
-         });
-
-        expect(wrapper.props('action')).toBe(fn);
-
-        await mainCheckbox.setChecked(true);
-
-        expect(fn).toHaveBeenCalledTimes(1);
-        expect(fn).toHaveBeenCalledWith(text);
-
-        //Hack to avoid state from crossing over to other unit tests
-        //Just undo the changes made and everything works fine
-        //Unchecking luckily also resets data
-        await mainCheckbox.setChecked(false);
-    });
-});
-
-describe("User Interactions", () => {
-    beforeAll(() => {
-        expect(Checkbox).toBeTruthy();
-    });
-
-    test("Click Checkbox", async () => {
-        const testValue = 'test';
-        const testModel = ['test1', 'test2'];
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
-
-        expect(mainCheckbox.element.checked).toBe(false);
-        expect(wrapper.vm.list_of_checked).toEqual([]);
-        expect(wrapper.vm.enabled).toBe(false);
-
-        await wrapper.setProps({ 
-            value: testValue,
-            model: [...testModel]
-         });
-        await mainCheckbox.setChecked(true);
-
-        expect(mainCheckbox.element.checked).toBe(true);
-        expect(wrapper.vm.list_of_checked).toEqual([...testModel, testValue]);
-        expect(wrapper.vm.enabled).toBe(true);
-
-        await mainCheckbox.setChecked(false);
-
-        expect(mainCheckbox.element.checked).toBe(false);
-        expect(wrapper.vm.list_of_checked).toEqual([...testModel]);
-        expect(wrapper.vm.enabled).toBe(false);
-    });
-});
-
-//Outputs
-
-describe("DOM Elements", () => {
-    beforeAll(() => {
-        expect(Checkbox).toBeTruthy();
-    });
-
-    test("Checkbox", () => {
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-
-        expect(wrapper.find('[data-test="main-checkbox"]').exists()).toBe(true);
-    });
-
-    test("Icon", async () => {
-        const testIcon = "arrow-right";
-        const wrapper = shallowMount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-
-        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
-
-        await wrapper.setProps({ icon: testIcon });
-
-        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
-
-        const icon = wrapper.get('[data-test="main-icon"]');
-
-        expect(icon.attributes('icon')).toBe(testIcon);
-    });
-});
-
-describe("Emits", () => {
-    beforeAll(() => {
-        expect(Checkbox).toBeTruthy();
-    });
-
-    test("Emit Checkbox Model", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Checkbox);
-        expect(wrapper.exists()).toBe(true);
-        const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
-
-        await wrapper.setProps({ value: testValue });
-        await mainCheckbox.setChecked(true);
-
-        expect(wrapper.emitted('update:model')).toHaveLength(1);
-        expect(wrapper.emitted('update:model')[0]).toEqual([[testValue]]);
-    });
-});
-
-describe("V-Models", () => {
-    beforeAll(() => {
-        expect(Checkbox).toBeTruthy();
-    });
-
-    test("V-Model Model", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Checkbox, {
-            props: {
-              model: [],
-              'onUpdate:model': (e) => wrapper.setProps({ model: e }),
-              value: testValue
-            }
+            expect(mainCheckbox.element.checked).toBe(false);
+            expect(wrapper.vm.enabled).toBe(false);
         });
-        
-        await wrapper.get('[data-test="main-checkbox"]').setChecked(true);
-        expect(wrapper.props('model')).toEqual([testValue]);
+
+        test("Checkbox Model", async () => {
+            const testArray = ['test1', 'test2'];
+            wrapper = mount(Checkbox, {
+                props: {
+                    model: [...testArray]
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+            expect(wrapper.vm.list_of_checked).toEqual(testArray);
+
+            await mainCheckbox.setChecked(true);
+
+            expect(wrapper.vm.list_of_checked).toEqual([...testArray, 0]);
+        });
+
+        test("Checkbox Action", async () => {
+            const fn = vi.fn();
+            const text = 'test';
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+            expect(wrapper.props().hasOwnProperty('action')).toBe(true);
+
+            await wrapper.setProps({
+                value: text,
+                action: fn
+            });
+
+            expect(wrapper.props('action')).toBe(fn);
+
+            await mainCheckbox.setChecked(true);
+
+            expect(fn).toHaveBeenCalledTimes(1);
+            expect(fn).toHaveBeenCalledWith(text);
+
+            //Hack to avoid state from crossing over to other unit tests
+            //Just undo the changes made and everything works fine
+            //Unchecking luckily also resets data
+            await mainCheckbox.setChecked(false);
+        });
+    });
+
+    describe("User Interactions", () => {
+        test("Click Checkbox", async () => {
+            const testValue = 'test';
+            const testModel = ['test1', 'test2'];
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+            expect(mainCheckbox.element.checked).toBe(false);
+            expect(wrapper.vm.list_of_checked).toEqual([]);
+            expect(wrapper.vm.enabled).toBe(false);
+
+            await wrapper.setProps({ 
+                value: testValue,
+                model: [...testModel]
+            });
+            await mainCheckbox.setChecked(true);
+
+            expect(mainCheckbox.element.checked).toBe(true);
+            expect(wrapper.vm.list_of_checked).toEqual([...testModel, testValue]);
+            expect(wrapper.vm.enabled).toBe(true);
+
+            await mainCheckbox.setChecked(false);
+
+            expect(mainCheckbox.element.checked).toBe(false);
+            expect(wrapper.vm.list_of_checked).toEqual([...testModel]);
+            expect(wrapper.vm.enabled).toBe(false);
+        });
+    });
+
+    //Outputs
+
+    describe("DOM Elements", () => {
+        test("Checkbox", () => {
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-checkbox"]').exists()).toBe(true);
+        });
+
+        test("Icon", async () => {
+            const testIcon = "arrow-right";
+            wrapper = shallowMount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
+
+            await wrapper.setProps({ icon: testIcon });
+
+            expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
+
+            const icon = wrapper.get('[data-test="main-icon"]');
+
+            expect(icon.attributes('icon')).toBe(testIcon);
+        });
+    });
+
+    describe("Emits", () => {
+        test("Emit Checkbox Model", async () => {
+            const testValue = 'test';
+            wrapper = mount(Checkbox);
+            expect(wrapper.exists()).toBe(true);
+            const mainCheckbox = wrapper.get('[data-test="main-checkbox"]');
+
+            await wrapper.setProps({ value: testValue });
+            await mainCheckbox.setChecked(true);
+
+            expect(wrapper.emitted('update:model')).toHaveLength(1);
+            expect(wrapper.emitted('update:model')[0]).toEqual([[testValue]]);
+        });
+    });
+
+    describe("V-Models", () => {
+        test("V-Model Model", async () => {
+            const testValue = 'test';
+            wrapper = mount(Checkbox, {
+                props: {
+                model: [],
+                'onUpdate:model': (e) => wrapper.setProps({ model: e }),
+                value: testValue
+                }
+            });
+            
+            await wrapper.get('[data-test="main-checkbox"]').setChecked(true);
+            expect(wrapper.props('model')).toEqual([testValue]);
+        });
     });
 });

--- a/__test__/components/kytos/inputs/Checkbox.test.js
+++ b/__test__/components/kytos/inputs/Checkbox.test.js
@@ -11,7 +11,6 @@ describe("Checkbox.vue", () => {
 
     afterEach(() => {
         wrapper.unmount();
-        wrapper = null;
         vi.restoreAllMocks();
     });
 
@@ -95,11 +94,6 @@ describe("Checkbox.vue", () => {
 
             expect(fn).toHaveBeenCalledTimes(1);
             expect(fn).toHaveBeenCalledWith(text);
-
-            //Hack to avoid state from crossing over to other unit tests
-            //Just undo the changes made and everything works fine
-            //Unchecking luckily also resets data
-            await mainCheckbox.setChecked(false);
         });
     });
 

--- a/__test__/components/kytos/inputs/Checkbox.test.js
+++ b/__test__/components/kytos/inputs/Checkbox.test.js
@@ -4,7 +4,7 @@ import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
 //Inputs
 
-describe.sequential("Props", () => {
+describe("Props", () => {
     beforeAll(() => {
         expect(Checkbox).toBeTruthy();
     });

--- a/__test__/components/kytos/inputs/Input.test.js
+++ b/__test__/components/kytos/inputs/Input.test.js
@@ -81,7 +81,6 @@ describe("Props", () => {
         expect(fn).toHaveBeenCalledTimes(1);
         expect(fn).toHaveBeenCalledWith(text);
     });
-
 });
 
 describe("User Interactions", () => {
@@ -164,9 +163,9 @@ describe("V-Models", () => {
               value: 'initialText',
               'onUpdate:value': (e) => wrapper.setProps({ value: e })
             }
-          })
+        });
         
-          await wrapper.get('[data-test="main-input"]').setValue(text)
-          expect(wrapper.props('value')).toBe(text)
+          await wrapper.get('[data-test="main-input"]').setValue(text);
+          expect(wrapper.props('value')).toBe(text);
         });
 });

--- a/__test__/components/kytos/inputs/Input.test.js
+++ b/__test__/components/kytos/inputs/Input.test.js
@@ -2,170 +2,160 @@ import { mount, shallowMount } from '@vue/test-utils';
 import Input from '@/components/kytos/inputs/Input.vue';
 import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
-//Inputs
 
-describe("Props", () => {
+
+describe("Input.vue", () => {
+    let wrapper;
     beforeAll(() => {
         expect(Input).toBeTruthy();
     });
 
     afterEach(() => {
+        wrapper.unmount();
         vi.restoreAllMocks();
     });
 
-    test("Disabling Input", async () => {
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-        expect(mainInput.element.hasAttribute('disabled')).toBe(false);
+    //Inputs
 
-        await wrapper.setProps({ isDisabled: true });
+    describe("Props", () => {
+        test("Disabling Input", async () => {
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+            expect(mainInput.element.hasAttribute('disabled')).toBe(false);
 
-        expect(mainInput.element.hasAttribute('disabled')).toBe(true);
-    });
+            await wrapper.setProps({ isDisabled: true });
 
-    test("Default Input Value", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        expect(mainInput.element.hasAttribute('value')).toBe(true);
-
-        await wrapper.setProps({ value: testValue });
-
-        expect(mainInput.attributes('value')).toBe(testValue);
-    });
-
-    test("Input Tooltip", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        expect(mainInput.element.hasAttribute('title')).toBe(false);
-
-        await wrapper.setProps({ tooltip: testValue });
-
-        expect(mainInput.attributes('title')).toBe(testValue);
-    });
-
-    test("Input Placeholder", async () => {
-        const testValue = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        expect(mainInput.element.hasAttribute('placeholder')).toBe(false);
-
-        await wrapper.setProps({ placeholder: testValue });
-
-        expect(mainInput.attributes('placeholder')).toBe(testValue);
-    });
-
-    test("Input Action", async () => {
-        const fn = vi.fn();
-        const text = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        expect(wrapper.props().hasOwnProperty('action')).toBe(true);
-
-        await wrapper.setProps({ action: fn });
-
-        expect(wrapper.props('action')).toBe(fn);
-
-        await mainInput.setValue(text);
-
-        expect(fn).toHaveBeenCalledTimes(1);
-        expect(fn).toHaveBeenCalledWith(text);
-    });
-});
-
-describe("User Interactions", () => {
-    beforeAll(() => {
-        expect(Input).toBeTruthy();
-    });
-
-    test("Input Data/Write/Use Input", async () => {
-        const text = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        await mainInput.setValue(text);
-
-        expect(mainInput.element.value).toContain(text);
-    });
-});
-
-//Outputs
-
-describe("DOM Elements", () => {
-    beforeAll(() => {
-        expect(Input).toBeTruthy();
-    });
-
-    test("Input", () => {
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-
-        expect(wrapper.find('[data-test="main-input"]').exists()).toBe(true);
-    });
-
-    test("Icon", async () => {
-        const testIcon = "arrow-right";
-        const wrapper = shallowMount(Input);
-        expect(wrapper.exists()).toBe(true);
-
-        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
-
-        await wrapper.setProps({ icon: testIcon });
-
-        expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
-
-        const icon = wrapper.get('[data-test="main-icon"]');
-
-        expect(icon.attributes('icon')).toBe(testIcon);
-    });
-});
-
-describe("Emits", () => {
-    beforeAll(() => {
-        expect(Input).toBeTruthy();
-    });
-
-    test("Emit Input Value", async () => {
-        const text = 'test';
-        const wrapper = mount(Input);
-        expect(wrapper.exists()).toBe(true);
-        const mainInput = wrapper.get('[data-test="main-input"]');
-
-        await mainInput.setValue(text);
-
-        expect(wrapper.emitted('update:value')).toHaveLength(1);
-        expect(wrapper.emitted('update:value')[0]).toEqual([text]);
-    });
-});
-
-//V-Model
-
-describe("V-Models", () => {
-    beforeAll(() => {
-        expect(Input).toBeTruthy();
-    });
-
-    test("V-Model Value", async () => {
-        const text = 'test';
-        const wrapper = mount(Input, {
-            props: {
-              value: 'initialText',
-              'onUpdate:value': (e) => wrapper.setProps({ value: e })
-            }
+            expect(mainInput.element.hasAttribute('disabled')).toBe(true);
         });
-        
-          await wrapper.get('[data-test="main-input"]').setValue(text);
-          expect(wrapper.props('value')).toBe(text);
+
+        test("Default Input Value", async () => {
+            const testValue = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            expect(mainInput.element.hasAttribute('value')).toBe(true);
+
+            await wrapper.setProps({ value: testValue });
+
+            expect(mainInput.attributes('value')).toBe(testValue);
         });
+
+        test("Input Tooltip", async () => {
+            const testValue = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            expect(mainInput.element.hasAttribute('title')).toBe(false);
+
+            await wrapper.setProps({ tooltip: testValue });
+
+            expect(mainInput.attributes('title')).toBe(testValue);
+        });
+
+        test("Input Placeholder", async () => {
+            const testValue = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            expect(mainInput.element.hasAttribute('placeholder')).toBe(false);
+
+            await wrapper.setProps({ placeholder: testValue });
+
+            expect(mainInput.attributes('placeholder')).toBe(testValue);
+        });
+
+        test("Input Action", async () => {
+            const fn = vi.fn();
+            const text = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            expect(wrapper.props().hasOwnProperty('action')).toBe(true);
+
+            await wrapper.setProps({ action: fn });
+
+            expect(wrapper.props('action')).toBe(fn);
+
+            await mainInput.setValue(text);
+
+            expect(fn).toHaveBeenCalledTimes(1);
+            expect(fn).toHaveBeenCalledWith(text);
+        });
+    });
+
+    describe("User Interactions", () => {
+        test("Input Data/Write/Use Input", async () => {
+            const text = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            await mainInput.setValue(text);
+
+            expect(mainInput.element.value).toContain(text);
+        });
+    });
+
+    //Outputs
+
+    describe("DOM Elements", () => {
+        test("Input", () => {
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-input"]').exists()).toBe(true);
+        });
+
+        test("Icon", async () => {
+            const testIcon = "arrow-right";
+            wrapper = shallowMount(Input);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(false);
+
+            await wrapper.setProps({ icon: testIcon });
+
+            expect(wrapper.find('[data-test="main-icon"]').exists()).toBe(true);
+
+            const icon = wrapper.get('[data-test="main-icon"]');
+
+            expect(icon.attributes('icon')).toBe(testIcon);
+        });
+    });
+
+    describe("Emits", () => {
+        test("Emit Input Value", async () => {
+            const text = 'test';
+            wrapper = mount(Input);
+            expect(wrapper.exists()).toBe(true);
+            const mainInput = wrapper.get('[data-test="main-input"]');
+
+            await mainInput.setValue(text);
+
+            expect(wrapper.emitted('update:value')).toHaveLength(1);
+            expect(wrapper.emitted('update:value')[0]).toEqual([text]);
+        });
+    });
+
+    //V-Model
+
+    describe("V-Models", () => {
+        test("V-Model Value", async () => {
+            const text = 'test';
+            wrapper = mount(Input, {
+                props: {
+                value: 'initialText',
+                'onUpdate:value': (e) => wrapper.setProps({ value: e })
+                }
+            });
+            
+            await wrapper.get('[data-test="main-input"]').setValue(text);
+            expect(wrapper.props('value')).toBe(text);
+            });
+    });
 });

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -50,6 +50,16 @@ export default {
         default: function(value) { return }
       }
   },
+  emits: {
+    'update:model': (checked_items) => {
+      if (Array.isArray(checked_items)) {
+        return true
+      } else {
+        console.warn('Invalid update:model event payload!')
+        return false
+      }
+    }
+  },
   methods: {
     update_check(){
       if(this.enabled){
@@ -57,6 +67,7 @@ export default {
       }else{
         this.list_of_checked.splice(this.list_of_checked.indexOf(this.value),1);
       }
+      this.$emit('update:model', this.list_of_checked)
       this.action(this.value)
     }
   },

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -63,19 +63,20 @@ export default {
   },
   methods: {
     update_check(){
-      const list_of_checked = this.model;
+      this.list_of_checked = this.model;
       if(this.enabled){
-        list_of_checked.push(this.value)
+        this.list_of_checked.push(this.value)
       }else{
-        list_of_checked.splice(list_of_checked.indexOf(this.value), 1);
+        this.list_of_checked.splice(this.list_of_checked.indexOf(this.value), 1);
       }
-      this.$emit('update:model', list_of_checked)
+      this.$emit('update:model', this.list_of_checked)
       this.action(this.value)
     }
   },
   data () {
     return {
-      enabled: this.checked
+      enabled: this.checked,
+      list_of_checked: this.model
     }
   }
 }

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -28,7 +28,7 @@ export default {
        */
       model: {
         type: Array,
-        default: []
+        default: () => []
       },
       /**
        * The value to checkbox button.

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -28,6 +28,7 @@ export default {
        */
       model: {
         type: Array,
+        default: []
       },
       /**
        * The value to checkbox button.

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -53,32 +53,29 @@ export default {
   emits: {
     'update:model': (checked_items) => {
       if (Array.isArray(checked_items)) {
-        return true
+        return true;
       } else {
-        console.warn('Invalid update:model event payload!')
-        return false
+        console.warn('Invalid update:model event payload!');
+        return false;
       }
     }
   },
   methods: {
     update_check(){
+      const list_of_checked = this.model;
       if(this.enabled){
-        this.list_of_checked.push(this.value)
+        list_of_checked.push(this.value)
       }else{
-        this.list_of_checked.splice(this.list_of_checked.indexOf(this.value),1);
+        list_of_checked.splice(list_of_checked.indexOf(this.value), 1);
       }
-      this.$emit('update:model', this.list_of_checked)
+      this.$emit('update:model', list_of_checked)
       this.action(this.value)
     }
   },
   data () {
     return {
-      enabled: this.checked,
-      list_of_checked: this.model || []
+      enabled: this.checked
     }
-  },
-  mounted () {
-    $(document).ready(this.update_check)
   }
 }
 </script>

--- a/src/components/kytos/inputs/Checkbox.vue
+++ b/src/components/kytos/inputs/Checkbox.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="k-checkbox-wrap">
-  <icon v-if="icon && iconName" :icon="iconName"></icon>
+  <icon v-if="icon && iconName" :icon="iconName" data-test="main-icon"></icon>
   <label class="checkbox">
-    <input type="checkbox" id="checkbox" v-model="enabled" @change="update_check()">
+    <input type="checkbox" id="checkbox" v-model="enabled" @change="update_check()" data-test="main-checkbox">
     <span class="slider"></span>
   </label>
   {{title}}

--- a/src/components/kytos/inputs/Input.vue
+++ b/src/components/kytos/inputs/Input.vue
@@ -27,7 +27,8 @@ export default {
     * The value to input button.
     */
    value: {
-      default: ""
+      default: "",
+      type: String
    },
    /*
    * Tooltip string for the input.
@@ -56,7 +57,16 @@ export default {
       default: function(val) {return}
    }
   },
-  emits: ['update:value'],
+  emits: {
+    'update:value': (value) => {
+      if (typeof value === 'string' || value instanceof String) {
+        return true
+      } else {
+        console.warn('Invalid update:value event payload!')
+        return false
+      }
+    }
+  },
   methods: {
     updateText(){
       this.$emit('update:value', this.$refs.inputValue.value)


### PR DESCRIPTION
Closes #140 

### Summary

The unit tests for the `k-checkbox` are done.
Coverage decreased because emit validation cannot be tested, but is counted as a branch and additional lines of code.

### Local Tests

The unit tests are all green.

### End-to-End Tests
