### PR TITLE
Added unit tests for the accordion components

### DIFF
--- a/__test__/components/kytos/accordion/Accordion.test.js
+++ b/__test__/components/kytos/accordion/Accordion.test.js
@@ -1,0 +1,56 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import Accordion from '@/components/kytos/accordion/Accordion.vue';
+import AccordionItem from '@/components/kytos/accordion/AccordionItem.vue';
+import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
+
+
+
+describe("ButtonGroup.vue", () => {
+    let wrapper;
+    beforeAll(() => {
+        expect(Accordion).toBeTruthy();
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        vi.restoreAllMocks();
+    });
+
+    //Inputs
+
+    describe("Slots", () => {
+        test("Accordion Single Item in Slot", () => {
+            wrapper = mount(Accordion, {
+                slots: {
+                    default: AccordionItem
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const accordionItem = wrapper.findComponent(AccordionItem);
+
+            expect(accordionItem.exists()).toBe(true);
+        });
+
+        test("Accordion Multiple Items in Slot", () => {
+            wrapper = mount(Accordion, {
+                slots: {
+                    default: [AccordionItem, AccordionItem, AccordionItem]
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const accordionItems = wrapper.findAllComponents(AccordionItem);
+            expect(accordionItems.length).toBe(3);
+        });
+    });
+
+    //Outputs
+
+    describe("DOM Elements", () => {
+        test("Accordion Wrapper", () => {
+            wrapper = mount(Accordion);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-accordionwrapper"]').exists()).toBe(true);
+        });
+    });
+});

--- a/__test__/components/kytos/accordion/AccordionItem.test.js
+++ b/__test__/components/kytos/accordion/AccordionItem.test.js
@@ -1,0 +1,85 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import AccordionItem from '@/components/kytos/accordion/AccordionItem.vue';
+import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
+
+
+
+describe("ButtonGroup.vue", () => {
+    let wrapper;
+    beforeAll(() => {
+        expect(AccordionItem).toBeTruthy();
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        vi.restoreAllMocks();
+    });
+
+    //Inputs
+
+    describe("Slots", () => {
+        test("ButtonGroup Single Button in Slot", () => {
+            wrapper = mount(AccordionItem, {
+                slots: {
+                    default: '<div data-test="test">Test</div>'
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const div = wrapper.find('[data-test="test"]');
+
+            expect(div.exists()).toBe(true);
+            expect(div.text()).toBe('Test');
+        });
+
+        test("ButtonGroup Multiple Buttons in Slot", async () => {
+            wrapper = mount(AccordionItem, {
+                slots: {
+                    default: [
+                        '<div data-test="test">Test1</div>',
+                        '<div data-test="test">Test2</div>',
+                        '<div data-test="test">Test3</div>'
+                    ]
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+
+            const divs = wrapper.findAll('[data-test="test"]');
+            expect(divs.length).toBe(3);
+        });
+    });
+
+    describe("User Interactions", () => {
+        test("Open/Close Accordion Item", async () => {
+            wrapper = mount(AccordionItem, {
+                attachTo: document.body,
+                slots: {
+                    default: '<div data-test="test">Test</div>'
+                }
+            });
+            expect(wrapper.exists()).toBe(true);
+            const div = wrapper.find('[data-test="test"]');
+            const checkbox = wrapper.get('[data-test="main-accordionitem"]');
+            
+            expect(div.isVisible()).toBe(true);
+
+            await checkbox.setChecked(false);
+
+            expect(div.isVisible()).toBe(false);
+
+            await checkbox.setChecked(true);
+
+            expect(div.isVisible()).toBe(true);
+        });
+    });
+
+    //Outputs
+
+    describe("DOM Elements", () => {
+        test("Accordion Item", () => {
+            wrapper = mount(AccordionItem);
+            expect(wrapper.exists()).toBe(true);
+
+            expect(wrapper.find('[data-test="main-accordionitem"]').exists()).toBe(true);
+        });
+    });
+});

--- a/src/components/kytos/accordion/Accordion.vue
+++ b/src/components/kytos/accordion/Accordion.vue
@@ -1,7 +1,8 @@
 <template>
-<div class="accordion-wrapper">
+<div class="accordion-wrapper" data-test="main-accordionwrapper">
     <!-- @slot Slot to be filled with accordion item -->
-    <slot />
+    <slot>
+    </slot>
 </div>
 </template>
 
@@ -33,8 +34,6 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 export default {
     name: 'k-accordion',
     mixins: [KytosBaseWithIcon],
-    data: function() {
-    },
 }
 
 </script>

--- a/src/components/kytos/accordion/AccordionItem.vue
+++ b/src/components/kytos/accordion/AccordionItem.vue
@@ -2,9 +2,10 @@
   <div class="tab">
     <input class="k-accordion-input" :id="id" type="checkbox" name="tabs" 
       :checked="checked"
-      @input="checked = $event.target.checked" />
+      @input="checked = $event.target.checked"
+      data-test="main-accordionitem"/>
     <label class="k-accordion-label" :for="id">{{title}}</label>
-    <div class="tab-content">
+    <div v-show="checked" class="tab-content">
      <!-- @slot Empty Pannel, please define some items inside. -->
     <slot>
        <p>Empty Pannel created, please define some items inside.</p>
@@ -85,7 +86,6 @@ export default {
     overflow: hidden
 
   .tab-content
-    max-height: 0
     overflow: hidden
     width: 100%
     -webkit-transition: max-height .35s
@@ -97,10 +97,6 @@ export default {
       margin: 1em
 
 .k-accordion-input
-  &:checked
-    & ~ .tab-content
-      max-height: 100%
-      overflow: hidden
 
   &[type=checkbox]
     & + .k-accordion-label:after


### PR DESCRIPTION
Closes #167
Closes #169 

### Summary

The `k-accordion` and `k-accordion-item` have unit tests.
Fixed an issue that caused `k-accordion-item` to collapse improperly.

### Local Tests

The accordion components work well.

### End-to-End Tests
