### PR TITLE
Added helper functions for the posting of error notifications after an http request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Added pinia for state management
 - Replaced ``jquery ajax`` with axios
+- Added helper function for HTTP Requests
 
 [2025.1.0] - 2025-04-14
 ***********************

--- a/src/helpers/http-helpers.js
+++ b/src/helpers/http-helpers.js
@@ -1,22 +1,17 @@
-function format_error(str, error) {
-  //Regular expression matches strings with {s} or {d}
-  return str.replace(/{([sd])}/g, function (match) {
-    switch (match) {
-      case "{d}":
-        return error.response.data.description;
-      case "{s}":
-        return error.response.status;
-      default:
-        return match;
-    }
-  });
-}
-
-const post_error = (_this, error, title = "{s}", description = "{d}") => {
+const post_error = (
+  _this,
+  error,
+  title = "Status",
+  description = { prefix: "", suffix: "" }
+) => {
   let notification = {
     icon: "gear",
-    title: format_error(title, error),
-    description: format_error(description, error),
+    title: `${title} (${error.response.status}):`,
+    description: `${description.prefix}${
+      error.response.data.description
+        ? error.response.data.description
+        : error.response.data
+    }${description.suffix}`,
   };
 
   _this.$kytos.eventBus.$emit("setNotification", notification);

--- a/src/helpers/http-helpers.js
+++ b/src/helpers/http-helpers.js
@@ -1,3 +1,14 @@
+  /**
+   * @param {Object} _this - The current Vue component instance.
+   * @param {Object} error - The error returned by Axios.
+   * @param {string} title - A title for the error notification.
+   * @param {Object} description - A description object for the body of the error notification. This contains:
+   * @param {string} description.prefix - The text that will go before the error description from the error object.
+   * @param {string} description.suffix - The text that will go after the error description from the error object.
+   * @returns {void}
+   * @description Emits an error notification that will be displayed in the terminal.
+   */
+
 const post_error = (
   _this,
   error,

--- a/src/helpers/http-helpers.js
+++ b/src/helpers/http-helpers.js
@@ -2,9 +2,9 @@ function format_error(str, error) {
   //Regular expression matches strings with {s} or {d}
   return str.replace(/{([sd])}/g, function (match) {
     switch (match) {
-      case "d":
+      case "{d}":
         return error.response.data.description;
-      case "s":
+      case "{s}":
         return error.response.status;
       default:
         return match;

--- a/src/helpers/http-helpers.js
+++ b/src/helpers/http-helpers.js
@@ -1,0 +1,27 @@
+function format_error(str, error) {
+  //Regular expression matches strings with {s} or {d}
+  return str.replace(/{([sd])}/g, function (match) {
+    switch (match) {
+      case "d":
+        return error.response.data.description;
+      case "s":
+        return error.response.status;
+      default:
+        return match;
+    }
+  });
+}
+
+const post_error = (_this, error, title = "{s}", description = "{d}") => {
+  let notification = {
+    icon: "gear",
+    title: format_error(title, error),
+    description: format_error(description, error),
+  };
+
+  _this.$kytos.eventBus.$emit("setNotification", notification);
+};
+
+const http_helpers = { post_error };
+
+export default http_helpers;

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,9 @@ import { library, dom } from "@fortawesome/fontawesome-svg-core";
 import { fas } from '@fortawesome/free-solid-svg-icons'
 import { fab } from '@fortawesome/free-brands-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
+
+import http_helpers from './helpers/http-helpers';
+
 library.add(fas, far, fab)
 dom.watch();
 
@@ -130,6 +133,7 @@ kytos.config.globalProperties.$kytos_server_api =  window.kytos_server_api
 kytos.config.globalProperties.$kytos_version = version
 kytos.config.globalProperties.$kytos.eventBus = eventBus;
 kytos.config.globalProperties.$kytos.toRaw = toRaw;
+kytos.config.globalProperties.$http_helpers = http_helpers;
 
 kytos.config.globalProperties.$filters = {
   humanize_bytes(num, precision = 0, suffix = 'bps') {


### PR DESCRIPTION
Closes #175 

### Summary

Added a helper functions folder.
Added a helper function for posting error notifications from an HTTP request.
The function allows for dynamic error titles and descriptions.
Example:
`this.$http_helpers.post_error(this, error, title, {prefix: 'text', suffix: 'text'})`

The last parameter is a description object which takes in a prefix and a suffix.

### Local Tests

The error notification was sent, and there were no errors.

### End-to-End Tests
