### PR TITLE
Menubar Cleanup

### DIFF
--- a/src/components/kytos/misc/Menubar.vue
+++ b/src/components/kytos/misc/Menubar.vue
@@ -43,18 +43,6 @@ export default {
     setItem (item) {
       this.$kytos.eventBus.$emit("hideInfoPanel")
       this.activeItem = item
-      $(".k-toolbar").show();
-
-      this.$nextTick(function () {
-      // DOM is now updated
-        $(".k-toolbar .k-menu-item").not(":hidden").each(function() {
-            $(this).each(function(){
-                if ($(this).find(".compact").length == 0){
-                    $(".compacted .k-toolbar").css("display","none");
-                }
-            });
-        });
-      });
     },
   },
   computed: {
@@ -67,17 +55,6 @@ export default {
         let keyObject = {}
         keyObject[currentKey] = function() {
           self.activeItem = componentNumber
-          $(".k-toolbar").show();
-
-          self.$nextTick(function () {
-            $(".k-toolbar .k-menu-item").not(":hidden").each(function() {
-                $(self).each(function(){
-                    if ($(self).find(".compact").length == 0){
-                        $(".compacted .k-toolbar").css("display","none");
-                    }
-                });
-            });
-          });
         }
         keys.push(keyObject)
       }

--- a/src/components/kytos/napp/Toolbar.vue
+++ b/src/components/kytos/napp/Toolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class='k-toolbar'>
    <component v-for="(component, index) in toolbarItemsList"
-              v-show="active == (index+1)"
+              v-show="active == (index+1) && (!compacted)"
               :is='component.name'
               :key="component.name">
    </component>
@@ -22,6 +22,13 @@
       type: Number,
       required: true
    },
+   /**
+    * Wether the toolbar should be compacted or not
+    */
+   compacted: {
+    type: Boolean,
+    required: true
+   }
   },
    data () {
      return {


### PR DESCRIPTION
Closes #issue_number

### Summary

I cleaned up the code for the menubar component.
This is to prep it for unit tests and banish `jQuery` from whence it came.

### Local Tests

I was able to switch through the Napps on the menubar and got no errors.

### End-to-End Tests
