### PR TITLE
Fix map default

### DIFF
--- a/__test__/components/map/Map.test.js
+++ b/__test__/components/map/Map.test.js
@@ -1,0 +1,65 @@
+import { mount } from "@vue/test-utils";
+import Map from "@/components/kytos/map/Map.vue";
+import KytosTopology from '@/components/kytos/topology/Topology.vue';
+import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
+
+const mockMap = {
+  Map: vi.fn(() => ({
+    addControl: vi.fn(),
+    on: vi.fn(),
+    remove: vi.fn(),
+    setStyle: vi.fn(),
+    dragRotate: {
+      disable: vi.fn()
+    },
+  })),
+  NavigationControl: vi.fn(),
+  accessToken: vi.fn()
+}
+
+describe("Map.vue", () => {
+  let wrapper;
+  beforeAll(() => {
+    expect(Map).toBeTruthy();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    vi.restoreAllMocks();
+  });
+
+  describe("Props", () => {
+    test("Does Map exists?", () => {
+      wrapper = mount(Map, {
+          global: {
+            components: {
+              'k-topology': KytosTopology
+            },
+            mocks: {
+              $kytos: {eventBus: {$on: vi.fn()}},
+              $mapboxgl: mockMap,
+            }
+          },
+      });
+      expect(wrapper.exists()).toBe(true);
+    });
+  });
+
+  //Outputs
+  describe("DOM Elements", () => {
+      test("Map element", () => {
+        wrapper = mount(Map, {
+          global: {
+            components: {
+              'k-topology': KytosTopology
+            },
+            mocks: {
+              $kytos: {eventBus: {$on: vi.fn()}},
+              $mapboxgl: mockMap,
+            }
+          },
+        });
+        expect(wrapper.find('[data-test="map-container"]').exists()).toBe(true);
+      });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -8,9 +8,7 @@
     <link rel="shortcut icon" type="image/png" href="/src/assets/imgs/favicon.png"/>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <title>Kytos SDN Platform - Administrative Interface</title>
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.css' rel='stylesheet' />
-  </head>
+    </head>
   <body>
     <script src="src/main.js" type="module"></script>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@trevoreyre/autocomplete-vue": "^3.0.3",
     "axios": "^1.9.0",
     "d3": "^7.9.0",
-    "d3-request": "^1.0.6",
     "glob": "^7.2.0",
     "jsdocgen": "^0.2.4",
     "pinia": "^3.0.2",
@@ -35,7 +34,8 @@
     "v-hotkey3": "^0.1.4",
     "vue": "^3.1.0",
     "vue-docgen-api": "^4.43.2",
-    "write-file": "^1.0.0"
+    "write-file": "^1.0.0",
+    "mapbox-gl": "^2.15.0"
   },
   "devDependencies": {
     "@pinia/testing": "^1.0.1",

--- a/src/components/kytos/map/Map.vue
+++ b/src/components/kytos/map/Map.vue
@@ -1,14 +1,13 @@
 <template>
-  <div id="k-map" ref="mapContainer">
+  <div id="k-map" ref="mapContainer" data-test="map-container">
   </div>
-  <component v-bind:is="this.extraComponent" v-bind:map="this.map" v-bind:original_graph="this.topology.graph"></component>
+  <component v-bind:is="this.extraComponent" v-bind:map="this.map" v-bind:original_graph="this.topology.graph" data-test="map-topology"></component>
 </template>
 
 <script>
 import KytosBase from '../base/KytosBase';
 import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 import KytosTopology from '../topology/Topology.vue';
-import mapboxgl from 'mapbox-gl';
 
 
 export default {
@@ -63,9 +62,8 @@ export default {
     // Kytos mapbox style: "mapbox://styles/kytos/cj9e4mbtm6s532smy6767uftz"
     // Dark style: "mapbox://styles/mapbox/dark-v10",
     async loadMap () {
-      mapboxgl.accessToken = "pk.eyJ1Ijoia3l0b3MiLCJhIjoiY2o5ZTRsbHpnMjd3ZjMzbnJxc2xqa2hibyJ9.bBZPeP_YLA5oP0heHRpL6A";
-
-      const map = new mapboxgl.Map({
+      const map = new this.$mapboxgl.Map({
+        accessToken: "pk.eyJ1Ijoia3l0b3MiLCJhIjoiY2o5ZTRsbHpnMjd3ZjMzbnJxc2xqa2hibyJ9.bBZPeP_YLA5oP0heHRpL6A",
         container: this.$refs.mapContainer,
         style: this.map_style_kytos,
         center: this.map_center,
@@ -93,7 +91,7 @@ export default {
       });
 
       this.map = map;
-
+      
     },
     async getTopology () {
       console.log("Fetching topology data")
@@ -112,11 +110,11 @@ export default {
     }
   },
   async mounted () {
-    await this.loadMap();
+    this.loadMap();
     this.setListeners();
   },
   unmounted() {
-    this.map.remove();
+    this.map?.remove();
     this.map = null;
   }
 }

--- a/src/components/kytos/map/Map.vue
+++ b/src/components/kytos/map/Map.vue
@@ -66,11 +66,11 @@ export default {
       mapboxgl.accessToken = "pk.eyJ1Ijoia3l0b3MiLCJhIjoiY2o5ZTRsbHpnMjd3ZjMzbnJxc2xqa2hibyJ9.bBZPeP_YLA5oP0heHRpL6A";
 
       const map = new mapboxgl.Map({
-        container: "k-map",
-        style: this.map_style_empty,
+        container: this.$refs.mapContainer,
+        style: this.map_style_kytos,
         center: this.map_center,
         zoom: this.map_zoom,
-        hash: true
+        hash: false
       });
       
       map.dragRotate.disable();

--- a/src/components/kytos/map/Map.vue
+++ b/src/components/kytos/map/Map.vue
@@ -5,10 +5,10 @@
 </template>
 
 <script>
-import KytosBase from '../base/KytosBase'
-import KytosBaseWithIcon from '../base/KytosBaseWithIcon'
-import KytosTopology from '../topology/Topology.vue'
-import {json} from "d3-request"
+import KytosBase from '../base/KytosBase';
+import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
+import KytosTopology from '../topology/Topology.vue';
+
 
 export default {
   name: 'k-map',
@@ -57,7 +57,7 @@ export default {
         center: this.map_center,
         zoom: this.map_zoom
       })
-
+      
       map.dragRotate.disable()
 
       map.on("load", () => {
@@ -82,16 +82,18 @@ export default {
     getTopology () {
       let topoTimer = this.topoTimer
       console.log("Fetching topology data")
-      json(this.topology.url, (error, graph) => {
-        if (error) {
+
+      this.$http.get(this.topology.url)
+        .then(response => {
+          this.topology.graph = response.data.topology
+          this.extraComponent = KytosTopology
+        })
+        .catch(error => {
           var msg = "Error while trying to load the topology"
           this.$kytos.eventBus.$emit("statusMessage", msg, true)
           throw error
-        } else {
-          this.topology.graph = graph.topology
-          this.extraComponent = KytosTopology
-        }
-      })
+        });
+
     }
   },
   mounted () {

--- a/src/components/kytos/map/MapBoxSettings.vue
+++ b/src/components/kytos/map/MapBoxSettings.vue
@@ -9,9 +9,9 @@
 
           <k-accordion-item title="Background">
             <k-button-group>
-              <k-button tooltip="Map Background" icon="desktop"></k-button>
+              <k-button tooltip="Map Background" icon="desktop" @click="emitMapDefaultBackground"></k-button>
               <k-button tooltip="Image Background (disabled)" icon="image" :is-disabled="true"></k-button>
-              <k-button tooltip="No Background" icon="window-close"></k-button>
+              <k-button tooltip="No Background" icon="window-close" @click="emitMapNoBackground"></k-button>
             </k-button-group>
             <k-slider icon="adjust" :initial-value="mapOpacity" :action="emitMapOpacity"></k-slider>
           </k-accordion-item>
@@ -24,6 +24,12 @@
 export default {
 
   methods: {
+    emitMapNoBackground () {
+      this.$kytos.eventBus.$emit('change-map-no-background')
+    },
+    emitMapDefaultBackground () {
+      this.$kytos.eventBus.$emit('change-map-default-background')
+    },
     emitMapOpacity (value) {
       this.$kytos.eventBus.$emit('change-map-opacity', value)
     },

--- a/src/components/kytos/switch/Interface.vue
+++ b/src/components/kytos/switch/Interface.vue
@@ -21,7 +21,6 @@
 <script>
 import KytosBase from '../base/KytosBase'
 import InterfaceInfo from '../../../kytos/interfaceInfo.vue'
-import {json} from "d3-request"
 
 /**
  * Representation of the interfaces used.

--- a/src/components/kytos/topology/Topology.vue
+++ b/src/components/kytos/topology/Topology.vue
@@ -3,6 +3,7 @@
 
 <script>
 import * as d3 from "d3";
+import mapboxgl from "mapbox-gl";
 import KytosBase from '../base/KytosBase';
 import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 

--- a/src/components/kytos/topology/Topology.vue
+++ b/src/components/kytos/topology/Topology.vue
@@ -3,7 +3,6 @@
 
 <script>
 import * as d3 from "d3";
-import mapboxgl from "mapbox-gl";
 import KytosBase from '../base/KytosBase';
 import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 
@@ -285,7 +284,7 @@ export default {
       })
     },
     project (lat, lng) {
-      return this.map.project(new mapboxgl.LngLat(+lng, +lat))
+      return this.map.project(new this.$mapboxgl.LngLat(+lng, +lat))
     },
     get_interface_owner (d) {
       /* Get the switch in which the "d" interface is connected */

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -107,7 +107,6 @@
 
 <script>
 import KytosBaseWithIcon from "../components/kytos/base/KytosBaseWithIcon"
-import {json} from "d3-request"
 
 export default {
   name: 'k-interface-info',

--- a/src/kytos/switchRadar.vue
+++ b/src/kytos/switchRadar.vue
@@ -4,7 +4,6 @@
 
 <script>
 import KytosBaseWithIcon from '../components/kytos/base/KytosBaseWithIcon'
-import {json} from "d3-request"
 
 export default {
   name: 'k-switch-radar',

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,9 @@ window.$ = window.jQuery = $;
 import axios from 'axios';
 kytos.config.globalProperties.$http = axios;
 
+import mapboxgl from 'mapbox-gl';
+kytos.config.globalProperties.$mapboxgl = mapboxgl;
+
 import * as d3 from 'd3';
 window.d3 = window.D3 = d3;
 window.kytos_server = location.protocol + "//" + location.host + "/";


### PR DESCRIPTION
Closes #69 and #81 

### Summary

Fix buttons to set map background to Kytos Style and Empty Style.
![image](https://github.com/user-attachments/assets/aabbdb22-06be-4504-94b9-bf299118a8d1)

Upgrade maptoolbox-gl to 2.15.0 in order to fix the buttons.

### Local Tests
- Run unit tests
- Open UI and click on the background related buttons
