### PR TITLE
Fix to not include web-ui folder in latest.zip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Added
 - Replaced ``jquery ajax`` with axios
 - Added helper function for HTTP Requests
 
+Changed
+=======
+- Fixed build of latest.zip file used in releases to not include the web-ui folder
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite serve",
     "build": "vite build --emptyOutDir",
     "preprod": "vite build --emptyOutDir --mode preprod",
-    "zip": "vite build --emptyOutDir > /dev/null && zip -r latest.zip web-ui/index.html web-ui/dist",
+    "zip": "vite build --emptyOutDir > /dev/null && (cd web-ui && zip -r ../latest.zip index.html dist)",
     "preview": "vite preview",
     "test": "vitest",
     "test-run": "vitest run",


### PR DESCRIPTION
Closes #223 
I also manuallly patched the latest.zip file on Github.

### Summary
Fix the script´s `npm run zip` command to not include the parent web-ui folder inside the latest.zip file that is generated to be used as the release file.
