### PR TITLE
Interface Details Menu tabs are now collapsed by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Changed
+=======
+- The tabs in the Interface Details Menu are now collapsed by default
+
 Added
 =====
 - Added pinia for state management

--- a/__test__/components/kytos/accordion/Accordion.test.js
+++ b/__test__/components/kytos/accordion/Accordion.test.js
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
 
 
-describe("ButtonGroup.vue", () => {
+describe("Accordion.vue", () => {
     let wrapper;
     beforeAll(() => {
         expect(Accordion).toBeTruthy();

--- a/__test__/components/kytos/accordion/AccordionItem.test.js
+++ b/__test__/components/kytos/accordion/AccordionItem.test.js
@@ -1,85 +1,129 @@
-import { mount, shallowMount } from '@vue/test-utils';
-import AccordionItem from '@/components/kytos/accordion/AccordionItem.vue';
+import { mount, shallowMount } from "@vue/test-utils";
+import AccordionItem from "@/components/kytos/accordion/AccordionItem.vue";
 import { describe, test, expect, beforeAll, afterEach, vi } from "vitest";
 
+describe("AccordionItem.vue", () => {
+  let wrapper;
+  beforeAll(() => {
+    expect(AccordionItem).toBeTruthy();
+  });
 
+  afterEach(() => {
+    wrapper.unmount();
+    vi.restoreAllMocks();
+  });
 
-describe("ButtonGroup.vue", () => {
-    let wrapper;
-    beforeAll(() => {
-        expect(AccordionItem).toBeTruthy();
+  //Inputs
+
+  describe("Props", () => {
+    test("True defaultState", async () => {
+      wrapper = mount(AccordionItem, {
+        attachTo: document.body,
+        props: {
+          defaultState: true,
+        },
+        slots: {
+          default: '<div data-test="test">Test</div>',
+        },
+      });
+      expect(wrapper.exists()).toBe(true);
+      const div = wrapper.find('[data-test="test"]');
+      const checkbox = wrapper.get('[data-test="main-accordionitem"]');
+
+      expect(div.isVisible()).toBe(true);
+
+      await checkbox.setChecked(false);
+
+      expect(div.isVisible()).toBe(false);
     });
 
-    afterEach(() => {
-        wrapper.unmount();
-        vi.restoreAllMocks();
+    test("False defaultState", async () => {
+      wrapper = mount(AccordionItem, {
+        attachTo: document.body,
+        props: {
+          defaultState: false,
+        },
+        slots: {
+          default: '<div data-test="test">Test</div>',
+        },
+      });
+      expect(wrapper.exists()).toBe(true);
+      const div = wrapper.find('[data-test="test"]');
+      const checkbox = wrapper.get('[data-test="main-accordionitem"]');
+
+      expect(div.isVisible()).toBe(false);
+
+      await checkbox.setChecked(true);
+
+      expect(div.isVisible()).toBe(true);
+    });
+  });
+
+  describe("Slots", () => {
+    test("AccordionItem Single elements in Slot", () => {
+      wrapper = mount(AccordionItem, {
+        slots: {
+          default: '<div data-test="test">Test</div>',
+        },
+      });
+      expect(wrapper.exists()).toBe(true);
+      const div = wrapper.find('[data-test="test"]');
+
+      expect(div.exists()).toBe(true);
+      expect(div.text()).toBe("Test");
     });
 
-    //Inputs
+    test("AccordionItem Multiple elements in Slot", async () => {
+      wrapper = mount(AccordionItem, {
+        slots: {
+          default: [
+            '<div data-test="test">Test1</div>',
+            '<div data-test="test">Test2</div>',
+            '<div data-test="test">Test3</div>',
+          ],
+        },
+      });
+      expect(wrapper.exists()).toBe(true);
 
-    describe("Slots", () => {
-        test("ButtonGroup Single Button in Slot", () => {
-            wrapper = mount(AccordionItem, {
-                slots: {
-                    default: '<div data-test="test">Test</div>'
-                }
-            });
-            expect(wrapper.exists()).toBe(true);
-            const div = wrapper.find('[data-test="test"]');
-
-            expect(div.exists()).toBe(true);
-            expect(div.text()).toBe('Test');
-        });
-
-        test("ButtonGroup Multiple Buttons in Slot", async () => {
-            wrapper = mount(AccordionItem, {
-                slots: {
-                    default: [
-                        '<div data-test="test">Test1</div>',
-                        '<div data-test="test">Test2</div>',
-                        '<div data-test="test">Test3</div>'
-                    ]
-                }
-            });
-            expect(wrapper.exists()).toBe(true);
-
-            const divs = wrapper.findAll('[data-test="test"]');
-            expect(divs.length).toBe(3);
-        });
+      const divs = wrapper.findAll('[data-test="test"]');
+      expect(divs.length).toBe(3);
     });
+  });
 
-    describe("User Interactions", () => {
-        test("Open/Close Accordion Item", async () => {
-            wrapper = mount(AccordionItem, {
-                attachTo: document.body,
-                slots: {
-                    default: '<div data-test="test">Test</div>'
-                }
-            });
-            expect(wrapper.exists()).toBe(true);
-            const div = wrapper.find('[data-test="test"]');
-            const checkbox = wrapper.get('[data-test="main-accordionitem"]');
-            
-            expect(div.isVisible()).toBe(true);
+  describe("User Interactions", () => {
+    test("Open/Close AccordionItem", async () => {
+      wrapper = mount(AccordionItem, {
+        attachTo: document.body,
+        slots: {
+          default: '<div data-test="test">Test</div>',
+        },
+      });
+      expect(wrapper.exists()).toBe(true);
+      const div = wrapper.find('[data-test="test"]');
+      const checkbox = wrapper.get('[data-test="main-accordionitem"]');
 
-            await checkbox.setChecked(false);
+      expect(div.isVisible()).toBe(true);
 
-            expect(div.isVisible()).toBe(false);
+      await checkbox.setChecked(false);
 
-            await checkbox.setChecked(true);
+      expect(div.isVisible()).toBe(false);
 
-            expect(div.isVisible()).toBe(true);
-        });
+      await checkbox.setChecked(true);
+
+      expect(div.isVisible()).toBe(true);
     });
+  });
 
-    //Outputs
+  //Outputs
 
-    describe("DOM Elements", () => {
-        test("Accordion Item", () => {
-            wrapper = mount(AccordionItem);
-            expect(wrapper.exists()).toBe(true);
+  describe("DOM Elements", () => {
+    test("Accordion Item", () => {
+      wrapper = mount(AccordionItem);
+      expect(wrapper.exists()).toBe(true);
 
-            expect(wrapper.find('[data-test="main-accordionitem"]').exists()).toBe(true);
-        });
+      expect(wrapper.find('[data-test="main-accordionitem"]').exists()).toBe(
+        true
+      );
     });
+  });
 });

--- a/src/components/kytos/accordion/AccordionItem.vue
+++ b/src/components/kytos/accordion/AccordionItem.vue
@@ -38,9 +38,18 @@ export default {
   mixins: [KytosBaseWithIcon],
   data () {
     return {
-      checked: true
+      checked: this.defaultState
     }
-  }
+  },
+    props: {
+      /**
+       * Default State of the Accordion Item: Checked or Unchecked.
+       */
+      defaultState: {
+        type: Boolean,
+        default: true
+      },
+    }
 }
 </script>
 

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -10,7 +10,7 @@
         :action="state_toggle_interface"
         v-model:show-modal="show_modal_state_toggle">
       </k-modal>
-      <k-accordion-item title="Interface Plot" v-if="chartJsonData">
+      <k-accordion-item :defaultState="false" title="Interface Plot" v-if="chartJsonData">
         <k-button-group>
             <!-- input type="text" class="k-input" placeholder="Zoom" disabled -->
             <k-button title="5" tooltip="5 minutes" @click="change_plotRange(5)"></k-button>
@@ -22,14 +22,14 @@
         <k-chart-timeseries :interface_id="metadata.interface_id" :jsonData="chartJsonData" :display_legend="true" :chartHeight="200" ></k-chart-timeseries>
       </k-accordion-item>
 
-      <k-accordion-item title="Basic Details">
+      <k-accordion-item :defaultState="false" title="Basic Details">
           <k-property-panel>
             <template v-if="content"> 
               <k-property-panel-item :name="key" :value="value" :key="key" v-for="(value, key) in this.metadata"></k-property-panel-item>
             </template>
           </k-property-panel>
       </k-accordion-item>
-      <k-accordion-item title="Available Tags">
+      <k-accordion-item :defaultState="false" title="Available Tags">
         <div class="metadata_table">
           <table>
             <thead>
@@ -47,7 +47,7 @@
           </table>
         </div>
       </k-accordion-item>
-      <k-accordion-item title="Tag ranges">
+      <k-accordion-item :defaultState="false" title="Tag ranges">
         <div class="metadata_table">
           <table>
             <thead>
@@ -73,7 +73,7 @@
           <k-button title="Set tag_ranges" @click="set_tag_ranges"></k-button>
         </div>
       </k-accordion-item>
-      <k-accordion-item title="Metadata" v-if="Object.keys(this.metadata_items).length !== 0">
+      <k-accordion-item :defaultState="false" title="Metadata" v-if="Object.keys(this.metadata_items).length !== 0">
          <div class="metadata_table">
             <table>
               <thead>
@@ -91,7 +91,7 @@
             </table>
          </div>
       </k-accordion-item>
-      <k-accordion-item title="Metadata actions"> 
+      <k-accordion-item :defaultState="false" title="Metadata actions"> 
          <k-textarea title="Add metadata" icon="arrow-right" placeholder='Eg. {"node_name": "some_name", "address": "some_address"}' v-model:value="to_add"></k-textarea>
          <div class="metadata_container">
               <k-button title="Add metadata" @click="bt_add_metadata"></k-button>


### PR DESCRIPTION
Closes #220

### Summary

The tabs/accordion-items are now collapsed by default within the Interface Details Menu. 
The unit tests for the accordions were updated. 
The accordions now have a new prop called `defaultState` to set the default state.
True is expanded
False is collapsed

![image](https://github.com/user-attachments/assets/dd3f3feb-a746-431a-a5e2-c04a19f7ddae)


### Local Tests

The tabs/accordion-items in the Interface Details Menu were collapsed by default and no errors were thrown.
