### PR TITLE
[release 2025.1.1] fix: backported k-accordion-item `defaultState` props

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2025.1.1] - 2025-07-21
+***********************
+
+Added
+=====
+- Backported k-accordion-item ``defaultState`` props
+
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Added
 - Backported k-accordion-item ``defaultState`` props
 
 
+Changed
+=======
+- Fixed build of latest.zip file used in releases to not include the web-ui folder
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite serve",
     "build": "vite build --emptyOutDir",
     "preprod": "vite build --emptyOutDir --mode preprod",
-    "zip": "vite build --emptyOutDir > /dev/null && zip -r latest.zip web-ui/index.html web-ui/dist",
+    "zip": "vite build --emptyOutDir > /dev/null && (cd web-ui && zip -r ../latest.zip index.html dist)",
     "preview": "vite preview",
     "test": "vitest",
     "test-run": "vitest run",

--- a/src/components/kytos/accordion/AccordionItem.vue
+++ b/src/components/kytos/accordion/AccordionItem.vue
@@ -37,9 +37,18 @@ export default {
   mixins: [KytosBaseWithIcon],
   data () {
     return {
-      checked: true
+      checked: this.defaultState
     }
-  }
+  },
+    props: {
+      /**
+       * Default State of the Accordion Item: Checked or Unchecked.
+       */
+      defaultState: {
+        type: Boolean,
+        default: true
+      },
+    }
 }
 </script>
 


### PR DESCRIPTION
Closes #230 

### Summary

See updated changelog file 

### Local Tests

- I tested it with a 2025.1 env from scratch:

```

     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2025.1.0
```

- Before the PR:

<img width="288" height="907" alt="20250721_121142" src="https://github.com/user-attachments/assets/171b03fe-53dd-446e-905c-9a24b146ebac" />

- After this PR:

<img width="416" height="676" alt="20250721_122237" src="https://github.com/user-attachments/assets/b1af5f01-7c80-4494-a6bb-2d431cccd17a" />


### End-to-End Tests

N/A

