### PR TITLE
Autocomplete now has actions for both input and submit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 - Added pinia for state management
 - Replaced ``jquery ajax`` with axios
 - Added helper function for HTTP Requests
+- Autocompletes now supports actions for both input and submit
 
 Changed
 =======

--- a/src/components/kytos/inputs/InputAutocomplete.vue
+++ b/src/components/kytos/inputs/InputAutocomplete.vue
@@ -162,7 +162,11 @@ export default {
    /**
    * Function called after input changes.
    */
-   action: {
+   input_action: {
+      type: Function,
+      default: function(val) {return}
+   },
+   submit_action: {
       type: Function,
       default: function(val) {return}
    },
@@ -173,7 +177,7 @@ export default {
   methods: {
     updateText(event) {
       this.$emit('update:value', event.target.value)
-      this.action(event.target.value)
+      this.input_action(event.target.value)
     },
     /**
     * Autocomplete search results
@@ -195,7 +199,7 @@ export default {
     handleSubmit(result) {
       // handle the autocomplete submit event when the user selects a result from the list
       this.$emit('update:value', result)
-      this.action(result)
+      this.submit_action(result)
     },
     handleFocus(event) {
       this.focused = true


### PR DESCRIPTION
### Summary

Autocomplete can now have a function called on either input or submit, not just both. This allows for more control over the behavior of the autocomplete component.

### Local Tests

No errors occurred after testing.
