### PR TITLE
Fix notifications when updating tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ UNRELEASED - Under development
 
 Fixed
 =====
-
+- Fixed notifications from updating tag ranges not appearing.
 - Pinned ``axios`` version 1.14.0 to avoid compromised third party packages
 
 

--- a/src/kytos/interfaceInfo.vue
+++ b/src/kytos/interfaceInfo.vue
@@ -332,7 +332,7 @@ export default {
                          + _this.new_tag_ranges,
             icon: 'cog',
           }
-          _this.$kytos.$emit("setNotification", notification)
+          _this.$kytos.eventBus.$emit("setNotification", notification)
         })
         _request.fail(function(data) {
           let notification = {
@@ -341,7 +341,7 @@ export default {
                          + 'but there was an error obtaining the resized "available_tags". Try refreshing the page.',
             icon: 'cog',
           }
-          _this.$kytos.$emit("setNotification", notification)
+          _this.$kytos.eventBus.$emit("setNotification", notification)
         })
       });
       request.fail(function(data) {
@@ -350,7 +350,7 @@ export default {
           description: data.status + ': ' + ( data.responseJSON !== undefined ? data.responseJSON.description : data.responseText ) + ' "tag_ranges" was not set.',
           icon: 'cog',
         }
-        _this.$kytos.$emit("setNotification", notification)
+        _this.$kytos.eventBus.$emit("setNotification", notification)
       });
     },
     get_tag_types: function() {


### PR DESCRIPTION
### Summary

Fixes a typo in the javascript for the interfaceInfo, which prevented notifications about tag updates from being pushed out.

Screenshot of the notifications:

<img width="831" height="369" alt="image" src="https://github.com/user-attachments/assets/40bac124-5915-4bab-bd18-1543781bd5d2" />

