### PR TITLE
fix: pinned axios version 1.14.0 to avoid compromised third party packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Fixed
+=====
+
+- Pinned ``axios`` version 1.14.0 to avoid compromised third party packages
+
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.2",
     "@trevoreyre/autocomplete-vue": "^3.0.3",
-    "axios": "^1.13.2",
+    "axios": "1.14.0",
     "d3": "^7.9.0",
     "glob": "^7.2.3",
     "jsdocgen": "^0.2.4",


### PR DESCRIPTION
Closes #266 

### Summary

See updated changelog file 

### Local Tests

Successfully built it, locally tested and confirmed axios pinned correctly and no plain-crypto-js

```
❯ npm ls axios          
kytos-web-ui@2025.2.0 /home/viniarck/repos/ui
└── axios@1.14.0

❯ npm ls plain-crypto-js
kytos-web-ui@2025.2.0 /home/viniarck/repos/ui
└── (empty)


~/repos/ui chore/pin_axios* 
❯ npm run build

> kytos-web-ui@2025.2.0 build
> vite build --emptyOutDir

vite v6.4.1 building for production...
src/assets/js/chart/radarChart.js (459:26): "legend" is not exported by "node_modules/d3/src/index.js", im
ported by "src/assets/js/chart/radarChart.js".
src/assets/js/chart/radarChart.js (460:45): "legend" is not exported by "node_modules/d3/src/index.js", im
ported by "src/assets/js/chart/radarChart.js".
✓ 739 modules transformed.
web-ui/index.html                                0.71 kB │ gzip:     0.41 kB
web-ui/dist/favicon-Ck5l8ffD.png                 0.99 kB
web-ui/dist/kytosng_icon_white-stGM3KFu.svg     43.56 kB │ gzip:     7.48 kB
web-ui/dist/kytosng_logo_white-CIx14MaD.svg     53.37 kB │ gzip:     9.92 kB
web-ui/dist/index-tpOuG3Tf.css                  66.88 kB │ gzip:    11.36 kB
web-ui/dist/index-B0jtMC20.js                5,295.23 kB │ gzip: 1,649.35 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-opti
ons/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 3.73s
```

<img width="1330" height="739" alt="Screenshot 2026-03-31 at 9 05 58 AM" src="https://github.com/user-attachments/assets/3d4012d9-6530-4a8c-9d6d-4f42705d7ae0" />

