### PR TITLE
[Backport 2025.2.1] Pinned axios version 1.14.0 to avoid compromised third party packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Kytos-NG UI project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+[2025.2.1] - 2026-03-31
+***********************
+
+Fixed
+=====
+- Pinned ``axios`` version 1.14.0 to avoid compromised third party packages
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kytos-web-ui",
   "description": "Kytos-NG Web-ui project",
-  "version": "2025.2.0",
+  "version": "2025.2.1",
   "author": "Beraldo Leal <beraldo.leal@cern.ch>",
   "private": true,
   "type": "module",
@@ -26,7 +26,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.2",
     "@trevoreyre/autocomplete-vue": "^3.0.3",
-    "axios": "^1.13.2",
+    "axios": "1.14.0",
     "d3": "^7.9.0",
     "glob": "^7.2.3",
     "jsdocgen": "^0.2.4",


### PR DESCRIPTION
Backport of https://github.com/kytos-ng/ui/pull/267

### Summary

See updated changelog file 

### Local Tests

Successfully built it, locally tested and confirmed axios pinned correctly and no plain-crypto-js

<img width="1328" height="902" alt="Screenshot 2026-03-31 at 10 38 07 AM" src="https://github.com/user-attachments/assets/cd3edd6c-5ab1-481b-b7b0-0823b8e2a890" />




